### PR TITLE
Permite personalizar ventana de estabilidad para RE’MESH

### DIFF
--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -256,7 +256,11 @@ def aplicar_remesh_red(G) -> None:
 
 def aplicar_remesh_si_estabilizacion_global(G, pasos_estables_consecutivos: Optional[int] = None) -> None:
     # Ventanas y umbrales
-    w_estab = int(G.graph.get("REMESH_STABILITY_WINDOW", DEFAULTS["REMESH_STABILITY_WINDOW"]))
+    w_estab = (
+        pasos_estables_consecutivos
+        if pasos_estables_consecutivos is not None
+        else int(G.graph.get("REMESH_STABILITY_WINDOW", DEFAULTS["REMESH_STABILITY_WINDOW"]))
+    )
     frac_req = float(G.graph.get("FRACTION_STABLE_REMESH", DEFAULTS["FRACTION_STABLE_REMESH"]))
     req_extra = bool(G.graph.get("REMESH_REQUIRE_STABILITY", DEFAULTS["REMESH_REQUIRE_STABILITY"]))
     min_sync = float(G.graph.get("REMESH_MIN_PHASE_SYNC", DEFAULTS["REMESH_MIN_PHASE_SYNC"]))

--- a/tests/test_remesh.py
+++ b/tests/test_remesh.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+
+import networkx as nx
+
+# Asegurar que src esté en el path para importar tnfr
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "src"))
+
+from tnfr.constants import attach_defaults
+from tnfr.operators import aplicar_remesh_si_estabilizacion_global
+
+
+def test_aplicar_remesh_usa_parametro_personalizado():
+    G = nx.Graph()
+    G.add_node(0)
+    attach_defaults(G)
+
+    # Historial suficiente para el parámetro personalizado
+    hist = G.graph.setdefault("history", {})
+    hist["stable_frac"] = [1.0, 1.0, 1.0]
+
+    # Historial de EPI necesario para aplicar_remesh_red
+    tau = G.graph["REMESH_TAU"]
+    G.graph["_epi_hist"] = [{0: 0.0} for _ in range(tau + 1)]
+
+    # Sin parámetro personalizado no se debería activar
+    aplicar_remesh_si_estabilizacion_global(G)
+    assert "_last_remesh_step" not in G.graph
+
+    # Con parámetro personalizado se activa con 3 pasos estables
+    aplicar_remesh_si_estabilizacion_global(G, pasos_estables_consecutivos=3)
+    assert G.graph["_last_remesh_step"] == len(hist["stable_frac"])
+


### PR DESCRIPTION
## Summary
- Permite ajustar `aplicar_remesh_si_estabilizacion_global` mediante `pasos_estables_consecutivos`.
- Añade prueba unitaria para comprobar que el parámetro personalizado activa el RE’MESH.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af48643dc48321b0a1b462e05d0c46