### PR TITLE
Add remesh stability override test

### DIFF
--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -256,7 +256,10 @@ def aplicar_remesh_red(G) -> None:
 
 def aplicar_remesh_si_estabilizacion_global(G, pasos_estables_consecutivos: Optional[int] = None) -> None:
     # Ventanas y umbrales
-    w_estab = int(G.graph.get("REMESH_STABILITY_WINDOW", DEFAULTS["REMESH_STABILITY_WINDOW"]))
+    if pasos_estables_consecutivos is not None:
+        w_estab = int(pasos_estables_consecutivos)
+    else:
+        w_estab = int(G.graph.get("REMESH_STABILITY_WINDOW", DEFAULTS["REMESH_STABILITY_WINDOW"]))
     frac_req = float(G.graph.get("FRACTION_STABLE_REMESH", DEFAULTS["FRACTION_STABLE_REMESH"]))
     req_extra = bool(G.graph.get("REMESH_REQUIRE_STABILITY", DEFAULTS["REMESH_REQUIRE_STABILITY"]))
     min_sync = float(G.graph.get("REMESH_MIN_PHASE_SYNC", DEFAULTS["REMESH_MIN_PHASE_SYNC"]))

--- a/tests/test_remesh.py
+++ b/tests/test_remesh.py
@@ -1,0 +1,21 @@
+import sys, pathlib
+
+import networkx as nx
+
+# Ensure module path
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / 'src'))
+
+from tnfr.operators import aplicar_remesh_si_estabilizacion_global
+
+
+def test_remesh_uses_custom_stable_steps():
+    G = nx.path_graph(3)
+    # Configure defaults with a window larger than our custom value
+    G.graph['REMESH_STABILITY_WINDOW'] = 5
+    G.graph['FRACTION_STABLE_REMESH'] = 0.8
+    # Simulated history reaching stability
+    G.graph['history'] = {'stable_frac': [0.9, 0.9, 0.9]}
+
+    aplicar_remesh_si_estabilizacion_global(G, pasos_estables_consecutivos=3)
+
+    assert G.graph['_last_remesh_step'] == 3


### PR DESCRIPTION
## Summary
- allow `aplicar_remesh_si_estabilizacion_global` to override stability window via `pasos_estables_consecutivos`
- add test ensuring remesh triggers with a custom stability window

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af4864de9883218a01ff30f85c38cc