### PR TITLE
Fix phase sync observer math import and add history test

### DIFF
--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -44,15 +44,27 @@ def coherencia_global(G) -> float:
 
 
 def sincronía_fase(G) -> float:
-    X = list(math.cos(_get_attr(G.nodes[n], ALIAS_THETA, 0.0)) for n in G.nodes())
-    Y = list(math.sin(_get_attr(G.nodes[n], ALIAS_THETA, 0.0)) for n in G.nodes())
+    X = [math.cos(_get_attr(G.nodes[n], ALIAS_THETA, 0.0)) for n in G.nodes()]
+    Y = [math.sin(_get_attr(G.nodes[n], ALIAS_THETA, 0.0)) for n in G.nodes()]
     if not X:
         return 1.0
-    import math
-    th = math.atan2(sum(Y)/len(Y), sum(X)/len(X))
+    th = math.atan2(sum(Y) / len(Y), sum(X) / len(X))
     # varianza angular aproximada (0 = muy sincronizado)
     import statistics as st
-    var = st.pvariance([((_get_attr(G.nodes[n], ALIAS_THETA, 0.0) - th + math.pi) % (2*math.pi) - math.pi) for n in G.nodes()]) if len(X) > 1 else 0.0
+    var = (
+        st.pvariance(
+            [
+                (
+                    (_get_attr(G.nodes[n], ALIAS_THETA, 0.0) - th + math.pi)
+                    % (2 * math.pi)
+                    - math.pi
+                )
+                for n in G.nodes()
+            ]
+        )
+        if len(X) > 1
+        else 0.0
+    )
     return 1.0 / (1.0 + var)
 
 def orden_kuramoto(G) -> float:

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,18 @@
+import networkx as nx
+import pytest
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+from tnfr.dynamics import _update_history
+
+
+def test_phase_sync_and_kuramoto_recorded():
+    G = nx.Graph()
+    G.add_node(1, theta=0.0)
+    G.add_node(2, theta=0.0)
+    _update_history(G)
+    hist = G.graph.get("history", {})
+    assert hist["phase_sync"][-1] == pytest.approx(1.0)
+    assert "kuramoto_R" in hist
+    assert hist["kuramoto_R"][-1] == pytest.approx(1.0)


### PR DESCRIPTION
## Summary
- import `math` at module level for `sincronía_fase`
- add regression test verifying `phase_sync` and `kuramoto_R` history metrics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af49ab24c48321a278ded5ed44d50d