### PR TITLE
refactor: use relative imports within package

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -1,3 +1,4 @@
+
 from __future__ import annotations
 """
 TNFR — Teoría de la Naturaleza Fractal Resonante
@@ -9,41 +10,7 @@ Ecuación nodal:
 
 __version__ = "3.0.3"
 
-import sys as _sys
-
-# ------------------------------------------------------------
-# 1) Crear alias para módulos con imports absolutos entre sí
-#    (los submódulos usan cosas tipo `from constants import ...`)
-#    Por eso registramos primero: constants → helpers → operators → observers
-# ------------------------------------------------------------
-from . import constants as _constants
-_sys.modules.setdefault("constants", _constants)
-
-from . import helpers as _helpers
-_sys.modules.setdefault("helpers", _helpers)
-
-from . import operators as _operators
-_sys.modules.setdefault("operators", _operators)
-
-from . import observers as _observers
-_sys.modules.setdefault("observers", _observers)
-
-# ------------------------------------------------------------
-# 2) IMPORTAR dynamics y ALIAS antes de ontosim
-#    (porque ontosim hace `from dynamics import ...`)
-# ------------------------------------------------------------
-from . import dynamics as _dynamics
-_sys.modules.setdefault("dynamics", _dynamics)
-
-# ------------------------------------------------------------
-# 3) Ahora sí, importar ontosim y alias
-# ------------------------------------------------------------
-from . import ontosim as _ontosim
-_sys.modules.setdefault("ontosim", _ontosim)
-
-# ------------------------------------------------------------
-# 4) Re-exports de la API pública
-# ------------------------------------------------------------
+# Re-exports de la API pública
 from .dynamics import step, run, set_delta_nfr_hook
 from .ontosim import preparar_red
 from .observers import attach_standard_observer, coherencia_global, orden_kuramoto

--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -14,10 +14,10 @@ from __future__ import annotations
 from typing import Dict, Any, Iterable
 import math
 
-from observers import sincronía_fase, carga_glifica, orden_kuramoto, sigma_vector
-from operators import aplicar_remesh_si_estabilizacion_global
-from constants import DEFAULTS, ALIAS_VF, ALIAS_THETA, ALIAS_DNFR, ALIAS_EPI, ALIAS_SI, ALIAS_dEPI, ALIAS_D2EPI
-from helpers import (
+from .observers import sincronía_fase, carga_glifica, orden_kuramoto, sigma_vector
+from .operators import aplicar_remesh_si_estabilizacion_global
+from .constants import DEFAULTS, ALIAS_VF, ALIAS_THETA, ALIAS_DNFR, ALIAS_EPI, ALIAS_SI, ALIAS_dEPI, ALIAS_D2EPI
+from .helpers import (
      clamp, clamp01, list_mean, phase_distance,
      _get_attr, _set_attr, media_vecinal, fase_media,
      invoke_callbacks, reciente_glifo
@@ -394,7 +394,7 @@ def step(G, *, dt: float | None = None, use_Si: bool = True, apply_glyphs: bool 
 
     # 2) (opcional) Si
     if use_Si:
-        from helpers import compute_Si
+        from .helpers import compute_Si
         compute_Si(G, inplace=True)
 
     # 2b) Normalizadores para selector paramétrico (por paso)
@@ -403,7 +403,7 @@ def step(G, *, dt: float | None = None, use_Si: bool = True, apply_glyphs: bool 
     # 3) Selección glífica + aplicación
     if apply_glyphs:
         selector = G.graph.get("glyph_selector", default_glyph_selector)
-        from operators import aplicar_glifo
+        from .operators import aplicar_glifo
         window = int(G.graph.get("GLYPH_HYSTERESIS_WINDOW", DEFAULTS["GLYPH_HYSTERESIS_WINDOW"]))
         for n in G.nodes():
             g = selector(G, n)

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -13,7 +13,7 @@ try:
 except Exception:  # pragma: no cover
     nx = None  # type: ignore
 
-from constants import DEFAULTS, ALIAS_VF, ALIAS_THETA, ALIAS_DNFR, ALIAS_EPI, ALIAS_SI
+from .constants import DEFAULTS, ALIAS_VF, ALIAS_THETA, ALIAS_DNFR, ALIAS_EPI, ALIAS_SI
 
 # -------------------------
 # Utilidades numéricas

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -8,8 +8,8 @@ from collections import Counter
 from typing import Dict, Any
 import math
 
-from constants import ALIAS_DNFR, ALIAS_EPI, ALIAS_THETA, ALIAS_dEPI
-from helpers import _get_attr, list_mean, register_callback
+from .constants import ALIAS_DNFR, ALIAS_EPI, ALIAS_THETA, ALIAS_dEPI
+from .helpers import _get_attr, list_mean, register_callback
 
 # -------------------------
 # Observador estándar Γ(R)

--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -9,16 +9,16 @@ import networkx as nx
 import math
 import random
 
-from constants import DEFAULTS, attach_defaults
-from dynamics import step as _step, run as _run
-from dynamics import default_compute_delta_nfr
+from .constants import DEFAULTS, attach_defaults
+from .dynamics import step as _step, run as _run
+from .dynamics import default_compute_delta_nfr
 
 # API de alto nivel
 
 def preparar_red(G: nx.Graph, *, override_defaults: bool = False, **overrides) -> nx.Graph:
     attach_defaults(G, override=override_defaults)
     if overrides:
-        from constants import merge_overrides
+        from .constants import merge_overrides
         merge_overrides(G, **overrides)
     # Inicializaciones blandas
     G.graph.setdefault("history", {
@@ -47,7 +47,7 @@ def preparar_red(G: nx.Graph, *, override_defaults: bool = False, **overrides) -
     # Auto-attach del observador estándar si se pide
     if G.graph.get("ATTACH_STD_OBSERVER", False):
         try:
-            from observers import attach_standard_observer
+            from .observers import attach_standard_observer
             attach_standard_observer(G)
         except Exception as e:
             G.graph.setdefault("_callback_errors", []).append(

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -5,8 +5,8 @@ import math
 import random
 import hashlib
 
-from constants import DEFAULTS, ALIAS_VF, ALIAS_THETA, ALIAS_DNFR, ALIAS_EPI, ALIAS_D2EPI
-from helpers import _get_attr, _set_attr, clamp, clamp01, list_mean, fase_media, push_glifo, invoke_callbacks
+from .constants import DEFAULTS, ALIAS_VF, ALIAS_THETA, ALIAS_DNFR, ALIAS_EPI, ALIAS_D2EPI
+from .helpers import _get_attr, _set_attr, clamp, clamp01, list_mean, fase_media, push_glifo, invoke_callbacks
 
 """
 Este módulo implementa:

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,9 +1,6 @@
 import networkx as nx
 import pytest
-import pathlib
-import sys
 
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1] / "src"))
 from tnfr.dynamics import _update_history
 
 

--- a/tests/test_remesh.py
+++ b/tests/test_remesh.py
@@ -1,11 +1,4 @@
-import sys
-from pathlib import Path
-
 import networkx as nx
-
-# Asegurar que src esté en el path para importar tnfr
-ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / "src"))
 
 from tnfr.constants import attach_defaults
 from tnfr.operators import aplicar_remesh_si_estabilizacion_global


### PR DESCRIPTION
## Summary
- drop manual `sys.modules` aliasing
- use relative imports between tnfr modules
- remove test-only `sys.path` hacks and rely on installed package

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_68af54c7bb6083219d8dc139fee1e1cd