### PR TITLE
Use deque for EPI history and unify versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,12 @@
 ---
 
 **Mastering these pieces will let you extend the simulation, build analysis pipelines and connect the theory with computational applications.**
+
+## Testing
+
+Install the project in editable mode and run the test suite with `pytest`:
+
+```
+pip install -e .
+pytest
+```

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "teoria-de-la-naturaleza-fractal-resonante-tnfr",
-  "version": "1.0.0",
+  "version": "3.0.3",
   "private": true,
   "scripts": {
-    "build": "remix vite:build"
+    "build": "remix vite:build",
+    "test": "pytest"
   },
   "devDependencies": {
     "@remix-run/dev": "^2.17.0",

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -85,7 +85,6 @@ def media_vecinal(G, n, aliases: Iterable[str], default: float = 0.0) -> float:
 
 def fase_media(G, n) -> float:
     """Promedio circular de las fases de los vecinos."""
-    import math
     x = 0.0
     y = 0.0
     count = 0

--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import networkx as nx
 import math
 import random
+from collections import deque
 
 from .constants import DEFAULTS, attach_defaults
 from .dynamics import step as _step, run as _run
@@ -43,7 +44,9 @@ def preparar_red(G: nx.Graph, *, override_defaults: bool = False, **overrides) -
         "phase_R": [], 
         "phase_disr": [],
     })
-    G.graph.setdefault("_epi_hist", [])
+    tau = int(G.graph.get("REMESH_TAU", DEFAULTS["REMESH_TAU"]))
+    maxlen = max(2 * tau + 5, 64)
+    G.graph.setdefault("_epi_hist", deque(maxlen=maxlen))
     # Auto-attach del observador estándar si se pide
     if G.graph.get("ATTACH_STD_OBSERVER", False):
         try:

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -7,6 +7,7 @@ import hashlib
 
 from .constants import DEFAULTS, ALIAS_VF, ALIAS_THETA, ALIAS_DNFR, ALIAS_EPI, ALIAS_D2EPI
 from .helpers import _get_attr, _set_attr, clamp, clamp01, list_mean, fase_media, push_glifo, invoke_callbacks
+from collections import deque
 
 """
 Este módulo implementa:
@@ -186,7 +187,7 @@ def aplicar_remesh_red(G) -> None:
     """
     tau = int(G.graph.get("REMESH_TAU", DEFAULTS["REMESH_TAU"]))
     alpha, alpha_src = _remesh_alpha_info(G)
-    hist = G.graph.get("_epi_hist", [])
+    hist = G.graph.get("_epi_hist", deque())
     if len(hist) < tau + 1:
         return
 

--- a/tests/test_remesh.py
+++ b/tests/test_remesh.py
@@ -1,4 +1,5 @@
 import networkx as nx
+from collections import deque
 
 from tnfr.constants import attach_defaults
 from tnfr.operators import aplicar_remesh_si_estabilizacion_global
@@ -15,7 +16,8 @@ def test_aplicar_remesh_usa_parametro_personalizado():
 
     # Historial de EPI necesario para aplicar_remesh_red
     tau = G.graph["REMESH_TAU"]
-    G.graph["_epi_hist"] = [{0: 0.0} for _ in range(tau + 1)]
+    maxlen = max(2 * tau + 5, 64)
+    G.graph["_epi_hist"] = deque([{0: 0.0} for _ in range(tau + 1)], maxlen=maxlen)
 
     # Sin parámetro personalizado no se debería activar
     aplicar_remesh_si_estabilizacion_global(G)


### PR DESCRIPTION
## Summary
- Remove redundant math import in `fase_media`
- Track `_epi_hist` with a bounded `deque` and adjust initialisation/tests
- Align Node and Python versions; add `npm test` script and testing instructions

## Testing
- `pip install networkx`
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af5d62ba14832181d0725e3d3c2c30