### PR TITLE
Align licensing metadata, ignore build artifacts, improve docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Python artifacts
+__pycache__/
+*.py[cod]
+*.egg-info/
+.eggs/
+build/
+dist/
+.pytest_cache/
+.cache/
+
+# Node artifacts
+node_modules/
+*.tsbuildinfo
+
+# Misc
+*.log
+.env

--- a/README.md
+++ b/README.md
@@ -54,6 +54,9 @@
 
 **Mastering these pieces will let you extend the simulation, build analysis pipelines and connect the theory with computational applications.**
 
+## Optional Node environment
+The repository includes a minimal `package.json` and `netlify.toml` used for an experimental Remix web demo. They are not required for the core Python package; feel free to ignore them unless you plan to build the demo via `npm run build`.
+
 ## Testing
 
 Install the dependencies and project in editable mode before running the test suite with `pytest`:

--- a/meta.json
+++ b/meta.json
@@ -24,7 +24,7 @@
     "CIFR",
     "glifo activador"
   ],
-  "license": "https://www.gnu.org/licenses/gpl-3.0.html",
+  "license": "https://opensource.org/licenses/MIT",
   "url": "https://github.com/fermga/Teoria-de-la-naturaleza-fractal-resonante-TNFR-",
   "datePublished": "2025-05-05",
   "version": "1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "teoria-de-la-naturaleza-fractal-resonante-tnfr",
   "version": "3.0.3",
+  "license": "MIT",
   "private": true,
   "scripts": {
     "build": "remix vite:build",

--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -52,6 +52,7 @@ def _write_dnfr_metadata(G, *, weights: dict, hook_name: str, note: str | None =
 
 
 def default_compute_delta_nfr(G) -> None:
+    """Calcula ΔNFR mezclando gradientes de fase, EPI y νf según pesos."""
     w = G.graph.get("DNFR_WEIGHTS", DEFAULTS["DNFR_WEIGHTS"])  # dict
     w_phase = float(w.get("phase", 0.34))
     w_epi = float(w.get("epi", 0.33))

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -21,19 +21,23 @@ from .constants import DEFAULTS, ALIAS_VF, ALIAS_THETA, ALIAS_DNFR, ALIAS_EPI, A
 # -------------------------
 
 def clamp(x: float, a: float, b: float) -> float:
+    """Constriñe ``x`` al intervalo cerrado [a, b]."""
     return a if x < a else b if x > b else x
 
 
 def clamp_abs(x: float, m: float) -> float:
+    """Limita ``x`` al rango simétrico [-m, m] usando ``abs(m)``."""
     m = abs(m)
     return clamp(x, -m, m)
 
 
 def clamp01(x: float) -> float:
+    """Ataja ``x`` a la banda [0, 1]."""
     return clamp(x, 0.0, 1.0)
 
 
 def list_mean(xs: Iterable[float], default: float = 0.0) -> float:
+    """Promedio aritmético o ``default`` si ``xs`` está vacío."""
     try:
         return fmean(xs)
     except StatisticsError:
@@ -77,6 +81,7 @@ def _set_attr(d, aliases, value: float) -> None:
 # -------------------------
 
 def media_vecinal(G, n, aliases: Iterable[str], default: float = 0.0) -> float:
+    """Media del atributo indicado por ``aliases`` en los vecinos de ``n``."""
     vals: List[float] = []
     for v in G.neighbors(n):
         vals.append(_get_attr(G.nodes[v], aliases, default))
@@ -103,11 +108,13 @@ def fase_media(G, n) -> float:
 # -------------------------
 
 def push_glifo(nd: Dict[str, Any], glifo: str, window: int) -> None:
+    """Añade ``glifo`` al historial del nodo con tamaño máximo ``window``."""
     hist = nd.setdefault("hist_glifos", deque(maxlen=window))
     hist.append(str(glifo))
 
 
 def reciente_glifo(nd: Dict[str, Any], glifo: str, ventana: int) -> bool:
+    """Indica si ``glifo`` apareció en las últimas ``ventana`` emisiones."""
     hist = nd.get("hist_glifos")
     if not hist:
         return False


### PR DESCRIPTION
## Summary
- unify license metadata across files (MIT)
- add .gitignore for Python/Node artifacts
- expand helper docstrings and document ΔNFR default function
- clarify optional Node environment in README

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af6c55eef0832186a89f6bcfdd7738