### PR TITLE
Add canonical glyph grammar module with compatibility and T’HOL closure

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -15,11 +15,13 @@ from .dynamics import step, run, set_delta_nfr_hook
 from .ontosim import preparar_red
 from .observers import attach_standard_observer, coherencia_global, orden_kuramoto
 from .gamma import GAMMA_REGISTRY, eval_gamma, kuramoto_R_psi
+from .grammar import enforce_canonical_grammar, on_applied_glifo
 
 __all__ = [
     "preparar_red",
     "step", "run", "set_delta_nfr_hook",
     "attach_standard_observer", "coherencia_global", "orden_kuramoto",
     "GAMMA_REGISTRY", "eval_gamma", "kuramoto_R_psi",
+    "enforce_canonical_grammar", "on_applied_glifo",
     "__version__",
 ]

--- a/src/tnfr/constants.py
+++ b/src/tnfr/constants.py
@@ -156,6 +156,17 @@ DEFAULTS: Dict[str, Any] = {
     "CALLBACKS_STRICT": False,  # si True, un error en callback detiene; si False, se loguea y continúa
 }
 
+# Gramática glífica canónica
+DEFAULTS.setdefault("GRAMMAR_CANON", {
+    "enabled": True,                # activar la gramática canónica
+    "zhir_requires_oz_window": 3,   # cuántos pasos atrás buscamos O’Z
+    "zhir_dnfr_min": 0.05,          # si |ΔNFR|_norm < este valor, no permitimos Z’HIR sin O’Z
+    "thol_min_len": 2,
+    "thol_max_len": 6,
+    "thol_close_dnfr": 0.15,        # si el campo calma, cerramos con SH’A/NU’L
+    "si_high": 0.66,                # umbral para elegir NU’L vs SH’A al cerrar
+})
+
 
 # -------------------------
 # Utilidades

--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -18,6 +18,7 @@ import networkx as nx
 
 from .observers import sincronía_fase, carga_glifica, orden_kuramoto, sigma_vector
 from .operators import aplicar_remesh_si_estabilizacion_global
+from .grammar import select_and_apply_with_grammar
 from .constants import DEFAULTS, ALIAS_VF, ALIAS_THETA, ALIAS_DNFR, ALIAS_EPI, ALIAS_SI, ALIAS_dEPI, ALIAS_D2EPI
 from .gamma import eval_gamma
 from .helpers import (
@@ -440,9 +441,13 @@ def step(G, *, dt: float | None = None, use_Si: bool = True, apply_glyphs: bool 
         selector = G.graph.get("glyph_selector", default_glyph_selector)
         from .operators import aplicar_glifo
         window = int(G.graph.get("GLYPH_HYSTERESIS_WINDOW", DEFAULTS["GLYPH_HYSTERESIS_WINDOW"]))
+        use_canon = bool(G.graph.get("GRAMMAR_CANON", DEFAULTS.get("GRAMMAR_CANON", {})).get("enabled", False))
         for n in G.nodes():
-            g = selector(G, n)
-            aplicar_glifo(G, n, g, window=window)
+            if use_canon:
+                select_and_apply_with_grammar(G, n, selector, window)
+            else:
+                g = selector(G, n)
+                aplicar_glifo(G, n, g, window=window)
 
     # 4) Ecuación nodal
     update_epi_via_nodal_equation(G, dt=dt)

--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+from typing import Dict, Any, Set
+
+from .constants import (
+    DEFAULTS,
+    ALIAS_SI, ALIAS_DNFR, ALIAS_EPI,
+)
+from .helpers import _get_attr, clamp01, reciente_glifo
+from collections import deque
+
+# Glifos nominales (para evitar typos)
+AL = "A’L"; EN = "E’N"; IL = "I’L"; OZ = "O’Z"; UM = "U’M"; RA = "R’A"; SHA = "SH’A"; VAL = "VA’L"; NUL = "NU’L"; THOL = "T’HOL"; ZHIR = "Z’HIR"; NAV = "NA’V"; REMESH = "RE’MESH"
+
+# -------------------------
+# Estado de gramática por nodo
+# -------------------------
+
+def _gram_state(nd: Dict[str, Any]) -> Dict[str, Any]:
+    """Crea/retorna el estado de gramática nodal.
+    Campos:
+      - thol_open (bool)
+      - thol_len (int)
+    """
+    st = nd.setdefault("_GRAM", {"thol_open": False, "thol_len": 0})
+    st.setdefault("thol_open", False)
+    st.setdefault("thol_len", 0)
+    return st
+
+# -------------------------
+# Compatibilidades canónicas (siguiente permitido)
+# -------------------------
+CANON_COMPAT: Dict[str, Set[str]] = {
+    # Inicio / apertura
+    AL:   {EN, RA, NAV, VAL, UM},
+    EN:   {IL, UM, RA, NAV},
+    # Estabilización / difusión / acople
+    IL:   {RA, VAL, UM, SHA},
+    UM:   {RA, IL, VAL, NAV},
+    RA:   {IL, VAL, UM, NAV},
+    VAL:  {UM, RA, IL, NAV},
+    # Disonancia → transición → mutación
+    OZ:   {ZHIR, NAV},
+    ZHIR: {IL, NAV},
+    NAV:  {OZ, ZHIR, RA, IL, UM},
+    # Cierres / latencias
+    SHA:  {AL, EN},
+    NUL:  {AL, IL},
+    # Bloques autoorganizativos
+    THOL: {OZ, ZHIR, NAV, RA, IL, UM, SHA, NUL},
+}
+
+# Fallbacks canónicos si una transición no está permitida
+CANON_FALLBACK: Dict[str, str] = {
+    AL: EN, EN: IL, IL: RA, UM: RA, RA: IL, VAL: RA, OZ: ZHIR, ZHIR: IL, NAV: RA, SHA: AL, NUL: AL, THOL: NAV,
+}
+
+# -------------------------
+# Cierres T’HOL y precondiciones Z’HIR
+# -------------------------
+
+def _dnfr_norm(G, nd) -> float:
+    # Normalizador robusto: usa historial de |ΔNFR| máx guardado por dynamics (si existe)
+    norms = G.graph.get("_sel_norms") or {}
+    dmax = float(norms.get("dnfr_max", 1.0)) or 1.0
+    return clamp01(abs(_get_attr(nd, ALIAS_DNFR, 0.0)) / dmax)
+
+
+def _si(G, nd) -> float:
+    return clamp01(_get_attr(nd, ALIAS_SI, 0.5))
+
+# -------------------------
+# Núcleo: forzar gramática sobre un candidato
+# -------------------------
+
+def enforce_canonical_grammar(G, n, cand: str) -> str:
+    nd = G.nodes[n]
+    st = _gram_state(nd)
+    cfg = G.graph.get("GRAMMAR_CANON", DEFAULTS.get("GRAMMAR_CANON", {}))
+
+    # 0) Si vienen glifos fuera del alfabeto, no tocamos
+    if cand not in CANON_COMPAT:
+        return cand
+
+    # 1) Precondición O’Z→Z’HIR: mutación requiere disonancia reciente o campo fuerte
+    if cand == ZHIR:
+        win = int(cfg.get("zhir_requires_oz_window", 3))
+        dn_min = float(cfg.get("zhir_dnfr_min", 0.05))
+        if not reciente_glifo(nd, OZ, win) and _dnfr_norm(G, nd) < dn_min:
+            cand = OZ  # forzamos paso por O’Z
+
+    # 2) Si estamos dentro de T’HOL, control de cierre obligado
+    if st.get("thol_open", False):
+        st["thol_len"] = int(st.get("thol_len", 0))
+        st["thol_len"] += 1
+        minlen = int(cfg.get("thol_min_len", 2))
+        maxlen = int(cfg.get("thol_max_len", 6))
+        close_dn = float(cfg.get("thol_close_dnfr", 0.15))
+        if st["thol_len"] >= maxlen or (st["thol_len"] >= minlen and _dnfr_norm(G, nd) <= close_dn):
+            cand = NUL if _si(G, nd) >= float(cfg.get("si_high", 0.66)) else SHA
+
+    # 3) Compatibilidades: si el anterior restringe el siguiente
+    prev = None
+    hist = nd.get("hist_glifos")
+    if hist:
+        try:
+            prev = list(hist)[-1]
+        except Exception:
+            prev = None
+    if prev in CANON_COMPAT and cand not in CANON_COMPAT[prev]:
+        cand = CANON_FALLBACK.get(prev, cand)
+
+    return cand
+
+# -------------------------
+# Post-selección: actualizar estado de gramática
+# -------------------------
+
+def on_applied_glifo(G, n, applied: str) -> None:
+    nd = G.nodes[n]
+    st = _gram_state(nd)
+    if applied == THOL:
+        st["thol_open"] = True
+        st["thol_len"] = 0
+    elif applied in (SHA, NUL):
+        st["thol_open"] = False
+        st["thol_len"] = 0
+    else:
+        pass
+
+# -------------------------
+# Integración con dynamics.step: helper de selección+aplicación
+# -------------------------
+
+def select_and_apply_with_grammar(G, n, selector, window: int) -> None:
+    from .operators import aplicar_glifo
+    cand = selector(G, n)
+    cand = enforce_canonical_grammar(G, n, cand)
+    aplicar_glifo(G, n, cand, window=window)
+    on_applied_glifo(G, n, cand)

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -1,0 +1,56 @@
+import networkx as nx
+from collections import deque
+
+from tnfr.constants import attach_defaults
+from tnfr.grammar import (
+    enforce_canonical_grammar,
+    on_applied_glifo,
+    AL, EN, IL, OZ, ZHIR, THOL, SHA, NUL, NAV,
+)
+
+
+def make_graph():
+    import networkx as nx
+
+    G = nx.Graph()
+    G.add_node(0)
+    attach_defaults(G)
+    return G
+
+
+def test_compatibility_fallback():
+    G = make_graph()
+    from collections import deque
+
+    nd = G.nodes[0]
+    nd['hist_glifos'] = deque([AL])
+    assert enforce_canonical_grammar(G, 0, IL) == EN
+
+
+def test_precondition_oz_to_zhir():
+    G = make_graph()
+    from collections import deque
+
+    nd = G.nodes[0]
+    nd['hist_glifos'] = deque([NAV])
+    nd['ΔNFR'] = 0.0
+    assert enforce_canonical_grammar(G, 0, ZHIR) == OZ
+    nd['hist_glifos'] = deque([OZ])
+    assert enforce_canonical_grammar(G, 0, ZHIR) == ZHIR
+
+
+def test_thol_closure():
+    G = make_graph()
+    from collections import deque
+
+    nd = G.nodes[0]
+    nd['hist_glifos'] = deque([THOL])
+    on_applied_glifo(G, 0, THOL)
+    st = nd['_GRAM']
+    st['thol_len'] = 2
+    nd['ΔNFR'] = 0.0
+    nd['Si'] = 0.7
+    assert enforce_canonical_grammar(G, 0, EN) == NUL
+    nd['Si'] = 0.1
+    st['thol_len'] = 2
+    assert enforce_canonical_grammar(G, 0, EN) == SHA


### PR DESCRIPTION
## Summary
- implement canonical glyph grammar enforcing transition compatibilities, O’Z→Z’HIR precondition and T’HOL block closure
- hook grammar into dynamics and expose utilities in package API
- add tests covering compatibility fallback, O’Z→Z’HIR gate and T’HOL closure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af776f6a00832193181ffc334c419f