### PR TITLE
Add trace instrumentation and canonical docstrings

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -28,6 +28,7 @@ from .metrics import (
     latency_series, glifogram_series,
     glyph_top, glyph_dwell_stats,
 )
+from .trace import register_trace
 from .program import play, seq, block, target, wait, THOL, TARGET, WAIT
 
 __all__ = [
@@ -41,6 +42,7 @@ __all__ = [
     "push_sigma_snapshot", "sigma_series", "sigma_rose",
     "register_sigma_callback",
     "register_metrics_callbacks",
+    "register_trace",
     "Tg_global", "Tg_by_node",
     "latency_series", "glifogram_series",
     "glyph_top", "glyph_dwell_stats",

--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -125,6 +125,22 @@ def dnfr_epi_vf_mixed(G) -> None:
 # -------------------------
 
 def update_epi_via_nodal_equation(G, *, dt: float = None, t: float | None = None) -> None:
+    """Ecuación nodal TNFR.
+
+    Implementa la forma extendida de la ecuación nodal:
+        ∂EPI/∂t = νf · ΔNFR(t) + Γi(R)
+
+    Donde:
+      - EPI es la Estructura Primaria de Información del nodo.
+      - νf es la frecuencia estructural del nodo (Hz_str).
+      - ΔNFR(t) es el gradiente nodal (necesidad de reorganización),
+        típicamente una mezcla de componentes (p. ej. fase θ, EPI, νf).
+      - Γi(R) es el acoplamiento de red opcional en función del orden de Kuramoto R
+        (ver gamma.py), usado para modular la integración en red.
+
+    Referencias TNFR: ecuación nodal (manual), glosario νf/ΔNFR/EPI, operador Γ.
+    Efectos secundarios: cachea dEPI y actualiza EPI por integración explícita.
+    """
     if not isinstance(G, (nx.Graph, nx.DiGraph, nx.MultiGraph, nx.MultiDiGraph)):
         raise TypeError("G must be a networkx graph instance")
     if dt is None:

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -49,7 +49,15 @@ def gamma_none(G, node, t, cfg: Dict[str, Any]) -> float:
 
 
 def gamma_kuramoto_linear(G, node, t, cfg: Dict[str, Any]) -> float:
-    """Γ = β · (R - R0) · cos(θ_i - ψ)"""
+    """Acoplamiento lineal de Kuramoto para Γi(R).
+
+    Fórmula: Γ = β · (R - R0) · cos(θ_i - ψ)
+      - R ∈ [0,1] es el orden global de fase.
+      - ψ es la fase media (dirección de coordinación).
+      - β, R0 son parámetros (ganancia/umbral).
+
+    Uso: refuerza integración cuando la red ya exhibe coherencia de fase (R>R0).
+    """
     beta = float(cfg.get("beta", 0.0))
     R0 = float(cfg.get("R0", 0.0))
     R, psi = kuramoto_R_psi(G)

--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -73,6 +73,16 @@ def _si(G, nd) -> float:
 # -------------------------
 
 def enforce_canonical_grammar(G, n, cand: str) -> str:
+    """Valida/ajusta el glifo candidato según la gramática canónica.
+
+    Reglas clave:
+      - Compatibilidades de transición glífica (recorrido TNFR).
+      - O’Z→Z’HIR: la mutación requiere disonancia reciente o |ΔNFR| alto.
+      - T’HOL[...]: obliga cierre con SH’A o NU’L cuando el campo se estabiliza
+        o se alcanza el largo del bloque; mantiene estado por nodo.
+
+    Devuelve el glifo efectivo a aplicar.
+    """
     nd = G.nodes[n]
     st = _gram_state(nd)
     cfg = G.graph.get("GRAMMAR_CANON", DEFAULTS.get("GRAMMAR_CANON", {}))

--- a/src/tnfr/main.py
+++ b/src/tnfr/main.py
@@ -5,6 +5,7 @@ from . import preparar_red, run, __version__
 from .constants import merge_overrides, attach_defaults
 from .sense import register_sigma_callback
 from .metrics import register_metrics_callbacks
+from .trace import register_trace
 
 def main(argv: list[str] | None = None) -> None:
     p = argparse.ArgumentParser(
@@ -27,6 +28,7 @@ def main(argv: list[str] | None = None) -> None:
     attach_defaults(G)
     register_sigma_callback(G)
     register_metrics_callbacks(G)
+    register_trace(G)
     # Ejemplo: activar Γi(R) lineal con β=0.2 y R0=0.5
     merge_overrides(G, GAMMA={"type": "kuramoto_linear", "beta": 0.2, "R0": 0.5})
     run(G, args.steps)

--- a/src/tnfr/metrics.py
+++ b/src/tnfr/metrics.py
@@ -55,6 +55,14 @@ def _tg_state(nd: Dict[str, Any]) -> Dict[str, Any]:
 # -------------
 
 def _metrics_step(G, *args, **kwargs):
+    """Actualiza métricas operativas TNFR por paso.
+
+    - Tg (tiempo glífico): sumatoria de corridas por glifo (global y por nodo).
+    - Índice de latencia: fracción de nodos en SH’A.
+    - Glifograma: conteo o fracción por glifo en el paso.
+
+    Todos los resultados se guardan en G.graph['history'].
+    """
     if not G.graph.get("METRICS", DEFAULTS.get("METRICS", {})).get("enabled", True):
         return
 

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -154,6 +154,18 @@ _NAME_TO_OP = {
 
 
 def aplicar_glifo(G, n, glifo: str, *, window: Optional[int] = None) -> None:
+    """Aplica un glifo TNFR al nodo `n` con histéresis `window`.
+
+    Los 13 glifos implementan reorganizadores canónicos:
+      A’L (emisión), E’N (recepción), I’L (coherencia), O’Z (disonancia),
+      U’M (acoplamiento), R’A (resonancia), SH’A (silencio), VA’L (expansión),
+      NU’L (contracción), T’HOL (autoorganización), Z’HIR (mutación),
+      NA’V (transición), RE’MESH (recursividad).
+
+    Relación con la gramática: la selección previa debe pasar por
+    `enforce_canonical_grammar` (grammar.py) para respetar compatibilidades,
+    precondición O’Z→Z’HIR y cierres T’HOL[...].
+    """
     glifo = str(glifo)
     op = _NAME_TO_OP.get(glifo)
     if not op:

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -88,6 +88,16 @@ def sigma_vector_node(G, n, weight_mode: str | None = None) -> Dict[str, float] 
 
 
 def sigma_vector_global(G, weight_mode: str | None = None) -> Dict[str, float]:
+    """Vector global del plano del sentido σ.
+
+    Mapea el último glifo de cada nodo a un vector unitario en S¹, ponderado
+    por `Si` (o `EPI`/1), y promedia para obtener:
+      - componentes (x, y), magnitud |σ| y ángulo arg(σ).
+
+    Interpretación TNFR: |σ| mide cuán alineada está la red en su
+    **recorrido glífico**; arg(σ) indica la **dirección funcional** dominante
+    (p. ej., torno a I’L/RA para consolidación/distribución, O’Z/Z’HIR para cambio).
+    """
     cfg = G.graph.get("SIGMA", DEFAULTS["SIGMA"])
     weight_mode = weight_mode or cfg.get("weight", "Si")
     acc = complex(0.0, 0.0)

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+from typing import Any, Dict, List, Optional
+from collections import Counter
+
+from .constants import DEFAULTS
+from .helpers import register_callback
+
+try:
+    from .gamma import kuramoto_R_psi
+except Exception:  # pragma: no cover
+    def kuramoto_R_psi(G):
+        return 0.0, 0.0
+
+try:
+    from .sense import sigma_vector_global
+except Exception:  # pragma: no cover
+    def sigma_vector_global(G, *args, **kwargs):
+        return {"x": 1.0, "y": 0.0, "mag": 1.0, "angle": 0.0, "n": 0}
+
+# -------------------------
+# Defaults
+# -------------------------
+DEFAULTS.setdefault("TRACE", {
+    "enabled": True,
+    "capture": ["gamma", "grammar", "selector", "dnfr_mix", "callbacks", "thol_state", "sigma", "kuramoto", "glifo_counts"],
+    "history_key": "trace_meta",
+})
+
+# -------------------------
+# Helpers
+# -------------------------
+
+def _ensure_history(G):
+    if "history" not in G.graph:
+        G.graph["history"] = {}
+    return G.graph["history"]
+
+
+def _last_glifo(nd: Dict[str, Any]) -> str | None:
+    h = nd.get("hist_glifos")
+    if not h:
+        return None
+    try:
+        return list(h)[-1]
+    except Exception:
+        return None
+
+
+# -------------------------
+# Snapshots
+# -------------------------
+
+def _trace_before(G, *args, **kwargs):
+    if not G.graph.get("TRACE", DEFAULTS["TRACE"]).get("enabled", True):
+        return
+    cfg = G.graph.get("TRACE", DEFAULTS["TRACE"])
+    capture: List[str] = list(cfg.get("capture", []))
+    hist = _ensure_history(G)
+    key = cfg.get("history_key", "trace_meta")
+
+    meta: Dict[str, Any] = {"t": float(G.graph.get("_t", 0.0)), "phase": "before"}
+
+    if "gamma" in capture:
+        meta["gamma"] = dict(G.graph.get("GAMMA", {}))
+
+    if "grammar" in capture:
+        meta["grammar"] = dict(G.graph.get("GRAMMAR_CANON", {}))
+
+    if "selector" in capture:
+        sel = G.graph.get("glyph_selector")
+        meta["selector"] = getattr(sel, "__name__", str(sel)) if sel else None
+
+    if "dnfr_mix" in capture:
+        # tratar de capturar varias convenciones posibles
+        mix = G.graph.get("DNFR_MIX") or G.graph.get("DELTA_NFR_MIX") or G.graph.get("NFR_MIX")
+        meta["dnfr_mix"] = mix if isinstance(mix, dict) else {"value": mix}
+
+    if "callbacks" in capture:
+        # si el motor guarda los callbacks, exponer nombres por fase
+        cb = G.graph.get("_callbacks")
+        if isinstance(cb, dict):
+            out = {k: [getattr(f, "__name__", "fn") for (_, f, *_rest) in v] if isinstance(v, list) else None for k, v in cb.items()}
+            meta["callbacks"] = out
+
+    if "thol_state" in capture:
+        # cuántos nodos tienen bloque T’HOL abierto
+        th_open = 0
+        for n in G.nodes():
+            st = G.nodes[n].get("_GRAM", {})
+            if st.get("thol_open", False):
+                th_open += 1
+        meta["thol_open_nodes"] = th_open
+
+    hist.setdefault(key, []).append(meta)
+
+
+def _trace_after(G, *args, **kwargs):
+    if not G.graph.get("TRACE", DEFAULTS["TRACE"]).get("enabled", True):
+        return
+    cfg = G.graph.get("TRACE", DEFAULTS["TRACE"])
+    capture: List[str] = list(cfg.get("capture", []))
+    hist = _ensure_history(G)
+    key = cfg.get("history_key", "trace_meta")
+
+    meta: Dict[str, Any] = {"t": float(G.graph.get("_t", 0.0)), "phase": "after"}
+
+    if "kuramoto" in capture:
+        R, psi = kuramoto_R_psi(G)
+        meta["kuramoto"] = {"R": float(R), "psi": float(psi)}
+
+    if "sigma" in capture:
+        sv = sigma_vector_global(G)
+        meta["sigma"] = {"x": float(sv.get("x", 1.0)), "y": float(sv.get("y", 0.0)), "mag": float(sv.get("mag", 1.0)), "angle": float(sv.get("angle", 0.0))}
+
+    if "glifo_counts" in capture:
+        cnt = Counter()
+        for n in G.nodes():
+            g = _last_glifo(G.nodes[n])
+            if g:
+                cnt[g] += 1
+        meta["glifos"] = dict(cnt)
+
+    hist.setdefault(key, []).append(meta)
+
+
+# -------------------------
+# API
+# -------------------------
+
+def register_trace(G) -> None:
+    """Activa snapshots before/after step y vuelca metadatos operativos en history.
+
+    Guarda en G.graph['history'][TRACE.history_key] una lista de entradas {'phase': 'before'|'after', ...} con:
+      - gamma: especificación activa de Γi(R)
+      - grammar: configuración de gramática canónica
+      - selector: nombre del selector glífico
+      - dnfr_mix: mezcla (si el motor la expone en G.graph)
+      - callbacks: callbacks registrados por fase (si están en G.graph['_callbacks'])
+      - thol_open_nodes: cuántos nodos tienen bloque T’HOL abierto
+      - kuramoto: (R, ψ) de la red
+      - sigma: vector global del plano del sentido
+      - glifos: conteos por glifo tras el paso
+    """
+    register_callback(G, when="before_step", func=_trace_before, name="trace_before")
+    register_callback(G, when="after_step", func=_trace_after, name="trace_after")


### PR DESCRIPTION
## Summary
- add lightweight `trace` module to snapshot runtime metadata into graph history
- document core TNFR functions with canonical formulas and glossary references
- export and enable `register_trace` within library and CLI

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af7de5b2488321becb8bb3c002e85b