### PR TITLE
Add mini CLI, graph presets, and invariant tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 dependencies = ["networkx>=2.6"]
 
 [project.scripts]
-tnfr = "tnfr.main:main"
+tnfr = "tnfr.cli:main"
 
 [project.urls]
 Homepage = "https://pypi.org/project/tnfr/"

--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -30,6 +30,10 @@ from .metrics import (
 )
 from .trace import register_trace
 from .program import play, seq, block, target, wait, THOL, TARGET, WAIT
+from .cli import main as cli_main
+from .scenarios import build_graph
+from .presets import get_preset
+from .types import NodeState
 
 __all__ = [
     "preparar_red",
@@ -49,3 +53,5 @@ __all__ = [
     "play", "seq", "block", "target", "wait", "THOL", "TARGET", "WAIT",
     "__version__",
 ]
+
+__all__ += ["cli_main", "build_graph", "get_preset", "NodeState"]

--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+import argparse
+import json
+from typing import Any, Dict, List, Optional
+
+try:  # pragma: no cover - opcional
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - yaml es opcional
+    yaml = None
+
+import networkx as nx
+
+from .constants import inject_defaults, DEFAULTS
+from .sense import register_sigma_callback, sigma_series, sigma_rose
+from .metrics import (
+    register_metrics_callbacks,
+    Tg_global,
+    latency_series,
+    glifogram_series,
+    glyph_top,
+)
+from .trace import register_trace
+from .program import play, seq, block, wait, target
+from .dynamics import step, _update_history
+from .scenarios import build_graph
+from .presets import get_preset
+
+
+def _save_json(path: str, data: Any) -> None:
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+
+def _load_sequence(path: str) -> List[Any]:
+    with open(path, "r", encoding="utf-8") as f:
+        text = f.read()
+    if path.endswith(".yaml") or path.endswith(".yml"):
+        if not yaml:
+            raise RuntimeError("pyyaml no está instalado, usa JSON o instala pyyaml")
+        data = yaml.safe_load(text)
+    else:
+        data = json.loads(text)
+
+    def parse_token(tok: Any):
+        if isinstance(tok, str):
+            return tok
+        if isinstance(tok, dict):
+            if "WAIT" in tok:
+                return wait(int(tok["WAIT"]))
+            if "TARGET" in tok:
+                return target(tok["TARGET"])
+            if "THOL" in tok:
+                spec = tok["THOL"] or {}
+                b = [_parse_inner(x) for x in spec.get("body", [])]
+                return block(*b, repeat=int(spec.get("repeat", 1)), close=spec.get("close"))
+        raise ValueError(f"Token inválido: {tok}")
+
+    def _parse_inner(x: Any):
+        return parse_token(x)
+
+    return [parse_token(t) for t in data]
+
+
+def _attach_callbacks(G: nx.Graph) -> None:
+    inject_defaults(G, DEFAULTS)
+    register_sigma_callback(G)
+    register_metrics_callbacks(G)
+    register_trace(G)
+    _update_history(G)
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    G = build_graph(n=args.nodes, topology=args.topology, seed=args.seed)
+    _attach_callbacks(G)
+
+    if args.preset:
+        program = get_preset(args.preset)
+        play(G, program)
+    else:
+        steps = int(args.steps or 100)
+        for _ in range(steps):
+            step(G)
+
+    if args.save_history:
+        _save_json(args.save_history, G.graph.get("history", {}))
+
+    if args.summary:
+        tg = Tg_global(G, normalize=True)
+        lat = latency_series(G)
+        print("Top glifos por Tg:", glyph_top(G, k=5))
+        if lat["value"]:
+            print("Latencia media:", sum(lat["value"]) / max(1, len(lat["value"])) )
+    return 0
+
+
+def cmd_sequence(args: argparse.Namespace) -> int:
+    G = build_graph(n=args.nodes, topology=args.topology, seed=args.seed)
+    _attach_callbacks(G)
+
+    if args.preset:
+        program = get_preset(args.preset)
+    elif args.sequence_file:
+        program = _load_sequence(args.sequence_file)
+    else:
+        program = seq("A’L", "E’N", "I’L", block("O’Z", "Z’HIR", "I’L", repeat=1), "R’A", "SH’A")
+
+    play(G, program)
+
+    if args.save_history:
+        _save_json(args.save_history, G.graph.get("history", {}))
+    return 0
+
+
+def cmd_metrics(args: argparse.Namespace) -> int:
+    G = build_graph(n=args.nodes, topology=args.topology, seed=args.seed)
+    _attach_callbacks(G)
+    for _ in range(int(args.steps or 200)):
+        step(G)
+
+    tg = Tg_global(G, normalize=True)
+    lat = latency_series(G)
+    rose = sigma_rose(G)
+    glifo = glifogram_series(G)
+
+    out = {
+        "Tg_global": tg,
+        "latency_mean": (sum(lat["value"]) / max(1, len(lat["value"])) ) if lat["value"] else 0.0,
+        "rose": rose,
+        "glifogram": {k: v[:10] for k, v in glifo.items()},
+    }
+    if args.save:
+        _save_json(args.save, out)
+    else:
+        print(json.dumps(out, ensure_ascii=False, indent=2))
+    return 0
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    p = argparse.ArgumentParser(prog="tnfr")
+    sub = p.add_subparsers(dest="cmd")
+
+    p_run = sub.add_parser("run", help="Correr escenario libre o preset y opcionalmente exportar history")
+    p_run.add_argument("--nodes", type=int, default=24)
+    p_run.add_argument("--topology", choices=["ring", "complete", "erdos"], default="ring")
+    p_run.add_argument("--steps", type=int, default=200)
+    p_run.add_argument("--seed", type=int, default=1)
+    p_run.add_argument("--preset", type=str, default=None)
+    p_run.add_argument("--save-history", dest="save_history", type=str, default=None)
+    p_run.add_argument("--summary", action="store_true")
+    p_run.set_defaults(func=cmd_run)
+
+    p_seq = sub.add_parser("sequence", help="Ejecutar una secuencia (preset o YAML/JSON)")
+    p_seq.add_argument("--nodes", type=int, default=24)
+    p_seq.add_argument("--topology", choices=["ring", "complete", "erdos"], default="ring")
+    p_seq.add_argument("--seed", type=int, default=1)
+    p_seq.add_argument("--preset", type=str, default=None)
+    p_seq.add_argument("--sequence-file", type=str, default=None)
+    p_seq.add_argument("--save-history", dest="save_history", type=str, default=None)
+    p_seq.set_defaults(func=cmd_sequence)
+
+    p_met = sub.add_parser("metrics", help="Correr breve y volcar métricas clave")
+    p_met.add_argument("--nodes", type=int, default=24)
+    p_met.add_argument("--topology", choices=["ring", "complete", "erdos"], default="ring")
+    p_met.add_argument("--steps", type=int, default=300)
+    p_met.add_argument("--seed", type=int, default=1)
+    p_met.add_argument("--save", type=str, default=None)
+    p_met.set_defaults(func=cmd_metrics)
+
+    args = p.parse_args(argv)
+    if not hasattr(args, "func"):
+        p.print_help()
+        return 1
+    return int(args.func(args))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/tnfr/constants.py
+++ b/src/tnfr/constants.py
@@ -181,6 +181,20 @@ def attach_defaults(G, override: bool = False) -> None:
     G.graph["_tnfr_defaults_attached"] = True
 
 
+def inject_defaults(G, defaults: Dict[str, Any] = DEFAULTS, override: bool = False) -> None:
+    """Alias de conveniencia para inyectar ``DEFAULTS`` en ``G.graph``.
+
+    Permite pasar un diccionario de *defaults* alternativo y mantiene la
+    semántica de ``attach_defaults`` existente. Si ``override`` es ``True`` se
+    sobreescriben valores ya presentes.
+    """
+    G.graph.setdefault("_tnfr_defaults_attached", False)
+    for k, v in defaults.items():
+        if override or k not in G.graph:
+            G.graph[k] = v
+    G.graph["_tnfr_defaults_attached"] = True
+
+
 def merge_overrides(G, **overrides) -> None:
     """Aplica cambios puntuales a G.graph.
     Útil para ajustar pesos sin tocar DEFAULTS globales.

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -137,10 +137,26 @@ def _ensure_callbacks(G):
         cbs.setdefault(k, [])
     return cbs
 
-def register_callback(G, event: str, func):
-    """Registra un callback en G.graph['callbacks'][event]. Firma: func(G, ctx) -> None"""
+def register_callback(
+    G,
+    event: str | None = None,
+    func=None,
+    *,
+    when: str | None = None,
+    name: str | None = None,
+):
+    """Registra ``func`` como callback del ``event`` indicado.
+
+    Permite tanto la forma posicional ``register_callback(G, "after_step", fn)``
+    como la forma con palabras clave ``register_callback(G, when="after_step", func=fn)``.
+    El parámetro ``name`` se acepta por compatibilidad pero actualmente no se
+    utiliza.
+    """
+    event = event or when
     if event not in ("before_step", "after_step", "on_remesh"):
         raise ValueError(f"Evento desconocido: {event}")
+    if func is None:
+        raise TypeError("func es obligatorio")
     cbs = _ensure_callbacks(G)
     cbs[event].append(func)
     return func

--- a/src/tnfr/presets.py
+++ b/src/tnfr/presets.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+from .program import seq, block, wait
+
+
+_PRESETS = {
+    "arranque_resonante": seq("A’L", "E’N", "I’L", "R’A", "VA’L", "U’M", wait(3), "SH’A"),
+    "mutacion_contenida": seq("A’L", "E’N", block("O’Z", "Z’HIR", "I’L", repeat=2), "R’A", "SH’A"),
+    "exploracion_acople": seq(
+        "A’L",
+        "E’N",
+        "I’L",
+        "VA’L",
+        "U’M",
+        block("O’Z", "NA’V", "I’L", repeat=1),
+        "R’A",
+        "SH’A",
+    ),
+}
+
+
+def get_preset(name: str):
+    if name not in _PRESETS:
+        raise KeyError(f"Preset no encontrado: {name}")
+    return _PRESETS[name]

--- a/src/tnfr/scenarios.py
+++ b/src/tnfr/scenarios.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+from typing import Any
+import random
+import networkx as nx
+
+from .constants import inject_defaults, DEFAULTS
+
+
+def build_graph(n: int = 24, topology: str = "ring", seed: int | None = 1):
+    rng = random.Random(seed)
+    if topology == "ring":
+        G = nx.cycle_graph(n)
+    elif topology == "complete":
+        G = nx.complete_graph(n)
+    elif topology == "erdos":
+        G = nx.gnp_random_graph(n, 3.0 / n, seed=seed)
+    else:
+        G = nx.path_graph(n)
+
+    for i in G.nodes():
+        nd = G.nodes[i]
+        nd.setdefault("EPI", rng.uniform(0.1, 0.3))
+        nd.setdefault("νf", rng.uniform(0.8, 1.2))
+        nd.setdefault("θ", rng.uniform(-3.1416, 3.1416))
+        nd.setdefault("Si", rng.uniform(0.4, 0.7))
+
+    inject_defaults(G, DEFAULTS)
+    return G

--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Dict, Any
+
+
+@dataclass
+class NodeState:
+    EPI: float = 0.0
+    vf: float = 1.0   # νf
+    theta: float = 0.0  # θ
+    Si: float = 0.5
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def to_attrs(self) -> Dict[str, Any]:
+        d = {"EPI": self.EPI, "νf": self.vf, "θ": self.theta, "Si": self.Si}
+        d.update(self.extra)
+        return d

--- a/tests/test_cli_sanity.py
+++ b/tests/test_cli_sanity.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+import json
+from tnfr.cli import main
+
+
+def test_cli_metrics_runs(tmp_path):
+    out = tmp_path / "m.json"
+    rc = main(["metrics", "--nodes", "10", "--steps", "50", "--save", str(out)])
+    assert rc == 0
+    data = json.loads(out.read_text(encoding="utf-8"))
+    assert "Tg_global" in data
+    assert "latency_mean" in data

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+import math
+import pytest
+
+from tnfr.constants import inject_defaults, DEFAULTS
+from tnfr.scenarios import build_graph
+from tnfr.dynamics import step, _update_history
+from tnfr.operators import aplicar_glifo, aplicar_remesh_si_estabilizacion_global
+
+
+@pytest.fixture
+def G_small():
+    G = build_graph(n=8, topology="ring", seed=7)
+    inject_defaults(G, DEFAULTS)
+    _update_history(G)
+    return G
+
+
+def _repeat_steps(G, k: int):
+    for _ in range(k):
+        step(G)
+
+
+def test_clamps_numeric_stability(G_small):
+    _repeat_steps(G_small, 50)
+    epi_min = G_small.graph.get("EPI_MIN", -1e9)
+    epi_max = G_small.graph.get("EPI_MAX", 1e9)
+    for n in G_small.nodes():
+        x = float(G_small.nodes[n].get("EPI", 0.0))
+        assert math.isfinite(x)
+        assert x >= epi_min - 1e-6
+        assert x <= epi_max + 1e-6
+
+
+def test_conservation_under_IL_SHA(G_small):
+    for n in G_small.nodes():
+        nd = G_small.nodes[n]
+        nd["ΔNFR"] = 0.0
+        nd["νf"] = 1.0
+    G_small.graph["GAMMA"] = {"type": "none"}
+
+    epi0 = {n: float(G_small.nodes[n].get("EPI", 0.0)) for n in G_small.nodes()}
+
+    for _ in range(5):
+        for n in G_small.nodes():
+            aplicar_glifo(G_small, n, "I’L", window=1)
+    epi1 = {n: float(G_small.nodes[n].get("EPI", 0.0)) for n in G_small.nodes()}
+
+    for _ in range(5):
+        for n in G_small.nodes():
+            aplicar_glifo(G_small, n, "SH’A", window=1)
+    epi2 = {n: float(G_small.nodes[n].get("EPI", 0.0)) for n in G_small.nodes()}
+
+    for n in G_small.nodes():
+        assert abs(epi1[n] - epi0[n]) < 5e-3
+        assert abs(epi2[n] - epi1[n]) < 5e-2
+
+
+def test_remesh_cooldown_if_present(G_small):
+    cooldown = G_small.graph.get("REMESH_COOLDOWN", G_small.graph.get("REMESH_COOLDOWN_VENTANA", None))
+    if cooldown is None:
+        pytest.skip("No hay REMESH_COOLDOWN definido en el motor")
+
+    w_estab = int(G_small.graph.get("REMESH_STABILITY_WINDOW", 0))
+    sf = G_small.graph.setdefault("history", {}).setdefault("stable_frac", [])
+    sf.extend([1.0] * w_estab)
+    tau = int(G_small.graph.get("REMESH_TAU", 0))
+    snap = {n: G_small.nodes[n].get("EPI", 0.0) for n in G_small.nodes()}
+    from collections import deque
+    G_small.graph["_epi_hist"] = deque([snap.copy() for _ in range(tau + 1)], maxlen=tau + 1)
+
+    aplicar_remesh_si_estabilizacion_global(G_small)
+    events = list(G_small.graph.get("history", {}).get("remesh_events", []))
+    assert len(events) == 1
+
+    sf.append(1.0)
+    aplicar_remesh_si_estabilizacion_global(G_small)
+    events2 = list(G_small.graph.get("history", {}).get("remesh_events", []))
+    assert len(events2) == 1
+
+    sf.extend([1.0] * int(cooldown))
+    aplicar_remesh_si_estabilizacion_global(G_small)
+    events3 = list(G_small.graph.get("history", {}).get("remesh_events", []))
+    assert len(events3) == 2


### PR DESCRIPTION
## Summary
- add a small `tnfr` CLI with `run`, `sequence`, and `metrics` subcommands
- introduce `build_graph` factories, canonical sequence presets, and a `NodeState` dataclass
- extend constants and helpers with `inject_defaults` and flexible callback registration
- expand test suite with CLI smoke test and invariant checks

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af7f9369bc8321a0456260674d0ff8