### PR TITLE
Ensure canonical seeding and configurable Γ via CLI

### DIFF
--- a/meta.json
+++ b/meta.json
@@ -27,7 +27,7 @@
   "license": "https://opensource.org/licenses/MIT",
   "url": "https://github.com/fermga/Teoria-de-la-naturaleza-fractal-resonante-TNFR-",
   "datePublished": "2025-05-05",
-  "version": "1.0",
+  "version": "4.2.0",
   "isAccessibleForFree": true
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teoria-de-la-naturaleza-fractal-resonante-tnfr",
-  "version": "4.0.0",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teoria-de-la-naturaleza-fractal-resonante-tnfr",
-      "version": "4.0.0",
+      "version": "4.2.0",
       "devDependencies": {
         "@remix-run/dev": "^2.17.0",
         "@remix-run/vite": "npm:@remix-run/dev@^2.17.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teoria-de-la-naturaleza-fractal-resonante-tnfr",
-  "version": "4.0.0",
+  "version": "4.2.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "tnfr"
-version = "4.1.0"
+version = "4.2.0"
 description = "TNFR canónica: dinámica glífica modular sobre redes."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -8,10 +8,10 @@ Ecuación nodal:
     ∂EPI/∂t = νf · ΔNFR(t)
 """
 
-__version__ = "4.1.0"
+__version__ = "4.2.0"
 
 # Re-exports de la API pública
-from .dynamics import step, run, set_delta_nfr_hook
+from .dynamics import step, run, set_delta_nfr_hook, validate_canon
 from .ontosim import preparar_red
 from .observers import attach_standard_observer, coherencia_global, orden_kuramoto
 from .gamma import GAMMA_REGISTRY, eval_gamma, kuramoto_R_psi
@@ -38,7 +38,7 @@ from .types import NodeState
 
 __all__ = [
     "preparar_red",
-    "step", "run", "set_delta_nfr_hook",
+    "step", "run", "set_delta_nfr_hook", "validate_canon",
 
     "attach_standard_observer", "coherencia_global", "orden_kuramoto",
     "GAMMA_REGISTRY", "eval_gamma", "kuramoto_R_psi",

--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -21,7 +21,7 @@ from .metrics import (
 )
 from .trace import register_trace
 from .program import play, seq, block, wait, target
-from .dynamics import step, _update_history, default_glyph_selector, parametric_glyph_selector
+from .dynamics import step, _update_history, default_glyph_selector, parametric_glyph_selector, validate_canon
 from .gamma import GAMMA_REGISTRY
 from .scenarios import build_graph
 from .presets import get_preset
@@ -73,9 +73,14 @@ def _attach_callbacks(G: nx.Graph) -> None:
 def cmd_run(args: argparse.Namespace) -> int:
     G = build_graph(n=args.nodes, topology=args.topology, seed=args.seed)
     _attach_callbacks(G)
+    validate_canon(G)
     G.graph.setdefault("GRAMMAR_CANON", DEFAULTS["GRAMMAR_CANON"]).update({"enabled": bool(args.grammar_canon)})
     G.graph["glyph_selector"] = default_glyph_selector if args.selector == "basic" else parametric_glyph_selector
-    G.graph["GAMMA"] = {"type": args.gamma}
+    G.graph["GAMMA"] = {
+        "type": args.gamma_type,
+        "beta": args.gamma_beta,
+        "R0": args.gamma_R0,
+    }
 
     if args.preset:
         program = get_preset(args.preset)
@@ -100,9 +105,14 @@ def cmd_run(args: argparse.Namespace) -> int:
 def cmd_sequence(args: argparse.Namespace) -> int:
     G = build_graph(n=args.nodes, topology=args.topology, seed=args.seed)
     _attach_callbacks(G)
+    validate_canon(G)
     G.graph.setdefault("GRAMMAR_CANON", DEFAULTS["GRAMMAR_CANON"]).update({"enabled": bool(args.grammar_canon)})
     G.graph["glyph_selector"] = default_glyph_selector if args.selector == "basic" else parametric_glyph_selector
-    G.graph["GAMMA"] = {"type": args.gamma}
+    G.graph["GAMMA"] = {
+        "type": args.gamma_type,
+        "beta": args.gamma_beta,
+        "R0": args.gamma_R0,
+    }
 
     if args.preset:
         program = get_preset(args.preset)
@@ -121,9 +131,14 @@ def cmd_sequence(args: argparse.Namespace) -> int:
 def cmd_metrics(args: argparse.Namespace) -> int:
     G = build_graph(n=args.nodes, topology=args.topology, seed=args.seed)
     _attach_callbacks(G)
+    validate_canon(G)
     G.graph.setdefault("GRAMMAR_CANON", DEFAULTS["GRAMMAR_CANON"]).update({"enabled": bool(args.grammar_canon)})
     G.graph["glyph_selector"] = default_glyph_selector if args.selector == "basic" else parametric_glyph_selector
-    G.graph["GAMMA"] = {"type": args.gamma}
+    G.graph["GAMMA"] = {
+        "type": args.gamma_type,
+        "beta": args.gamma_beta,
+        "R0": args.gamma_R0,
+    }
     for _ in range(int(args.steps or 200)):
         step(G)
 
@@ -159,7 +174,9 @@ def main(argv: Optional[List[str]] = None) -> int:
     p_run.add_argument("--summary", action="store_true")
     p_run.add_argument("--no-canon", dest="grammar_canon", action="store_false", default=True, help="Desactiva gramática canónica")
     p_run.add_argument("--selector", choices=["basic", "param"], default="basic")
-    p_run.add_argument("--gamma", choices=list(GAMMA_REGISTRY.keys()), default="none")
+    p_run.add_argument("--gamma-type", choices=list(GAMMA_REGISTRY.keys()), default="none")
+    p_run.add_argument("--gamma-beta", type=float, default=0.0)
+    p_run.add_argument("--gamma-R0", type=float, default=0.0)
     p_run.set_defaults(func=cmd_run)
 
     p_seq = sub.add_parser("sequence", help="Ejecutar una secuencia (preset o YAML/JSON)")
@@ -169,6 +186,9 @@ def main(argv: Optional[List[str]] = None) -> int:
     p_seq.add_argument("--preset", type=str, default=None)
     p_seq.add_argument("--sequence-file", type=str, default=None)
     p_seq.add_argument("--save-history", dest="save_history", type=str, default=None)
+    p_seq.add_argument("--gamma-type", choices=list(GAMMA_REGISTRY.keys()), default="none")
+    p_seq.add_argument("--gamma-beta", type=float, default=0.0)
+    p_seq.add_argument("--gamma-R0", type=float, default=0.0)
     p_seq.set_defaults(func=cmd_sequence)
 
     p_met = sub.add_parser("metrics", help="Correr breve y volcar métricas clave")
@@ -178,7 +198,9 @@ def main(argv: Optional[List[str]] = None) -> int:
     p_met.add_argument("--seed", type=int, default=1)
     p_met.add_argument("--no-canon", dest="grammar_canon", action="store_false", default=True, help="Desactiva gramática canónica")
     p_met.add_argument("--selector", choices=["basic", "param"], default="basic")
-    p_met.add_argument("--gamma", choices=list(GAMMA_REGISTRY.keys()), default="none")
+    p_met.add_argument("--gamma-type", choices=list(GAMMA_REGISTRY.keys()), default="none")
+    p_met.add_argument("--gamma-beta", type=float, default=0.0)
+    p_met.add_argument("--gamma-R0", type=float, default=0.0)
     p_met.add_argument("--save", type=str, default=None)
     p_met.set_defaults(func=cmd_metrics)
 

--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -212,6 +212,17 @@ def aplicar_clamps_canonicos(nd: Dict[str, Any], G=None, node=None) -> None:
         _set_attr(nd, ALIAS_THETA, ((th + math.pi) % (2*math.pi) - math.pi))
 
 
+def validate_canon(G) -> None:
+    """Aplica clamps canónicos a todos los nodos de ``G``.
+
+    Envuelve fase y restringe ``EPI`` y ``νf`` a los rangos en ``G.graph``.
+    Si ``VALIDATORS_STRICT`` está activo, registra alertas en ``history``.
+    """
+    for n in G.nodes():
+        aplicar_clamps_canonicos(G.nodes[n], G, n)
+    return G
+
+
 def coordinar_fase_global_vecinal(G, fuerza_global: float | None = None, fuerza_vecinal: float | None = None) -> None:
     """
     Ajusta fase con mezcla GLOBAL+VECINAL.

--- a/src/tnfr/scenarios.py
+++ b/src/tnfr/scenarios.py
@@ -17,12 +17,18 @@ def build_graph(n: int = 24, topology: str = "ring", seed: int | None = 1):
     else:
         G = nx.path_graph(n)
 
+    # Valores canónicos para inicialización
+    inject_defaults(G, DEFAULTS)
+    vf_min = float(G.graph.get("VF_MIN", DEFAULTS["VF_MIN"]))
+    vf_max = float(G.graph.get("VF_MAX", DEFAULTS["VF_MAX"]))
+    th_min = float(G.graph.get("INIT_THETA_MIN", DEFAULTS.get("INIT_THETA_MIN", -3.1416)))
+    th_max = float(G.graph.get("INIT_THETA_MAX", DEFAULTS.get("INIT_THETA_MAX", 3.1416)))
+
     for i in G.nodes():
         nd = G.nodes[i]
         nd.setdefault("EPI", rng.uniform(0.1, 0.3))
-        nd.setdefault("νf", rng.uniform(0.8, 1.2))
-        nd.setdefault("θ", rng.uniform(-3.1416, 3.1416))
+        nd.setdefault("νf", rng.uniform(vf_min, vf_max))
+        nd.setdefault("θ", rng.uniform(th_min, th_max))
         nd.setdefault("Si", rng.uniform(0.4, 0.7))
 
-    inject_defaults(G, DEFAULTS)
     return G

--- a/tests/test_canon.py
+++ b/tests/test_canon.py
@@ -1,0 +1,30 @@
+from tnfr.scenarios import build_graph
+from tnfr.dynamics import validate_canon
+
+
+def test_build_graph_vf_within_limits():
+    G = build_graph(n=10, topology="ring", seed=42)
+    vf_min = G.graph["VF_MIN"]
+    vf_max = G.graph["VF_MAX"]
+    for n in G.nodes():
+        vf = G.nodes[n]["νf"]
+        assert vf_min <= vf <= vf_max
+
+
+def test_validate_canon_clamps():
+    G = build_graph(n=5, topology="ring", seed=1)
+    for n in G.nodes():
+        nd = G.nodes[n]
+        nd["νf"] = 2.0
+        nd["EPI"] = 2.0
+        nd["θ"] = 5.0
+    validate_canon(G)
+    vf_min = G.graph["VF_MIN"]
+    vf_max = G.graph["VF_MAX"]
+    epi_min = G.graph["EPI_MIN"]
+    epi_max = G.graph["EPI_MAX"]
+    for n in G.nodes():
+        nd = G.nodes[n]
+        assert vf_min <= nd["νf"] <= vf_max
+        assert epi_min <= nd["EPI"] <= epi_max
+        assert -3.1416 <= nd["θ"] <= 3.1416

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,5 +1,6 @@
 import pytest
 import networkx as nx
+import pytest
 
 from tnfr.dynamics import default_compute_delta_nfr, update_epi_via_nodal_equation
 

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -4,6 +4,11 @@ import pytest
 
 from tnfr.constants import inject_defaults, DEFAULTS
 from tnfr.scenarios import build_graph
+import math
+import pytest
+
+from tnfr.constants import inject_defaults, DEFAULTS
+from tnfr.scenarios import build_graph
 from tnfr.dynamics import step, _update_history
 from tnfr.operators import aplicar_glifo, aplicar_remesh_si_estabilizacion_global
 

--- a/tests/test_remesh.py
+++ b/tests/test_remesh.py
@@ -1,5 +1,6 @@
 import networkx as nx
 from collections import deque
+import networkx as nx
 
 from tnfr.constants import attach_defaults
 from tnfr.operators import aplicar_remesh_si_estabilizacion_global


### PR DESCRIPTION
## Summary
- Sample `νf` and `θ` within graph limits to avoid initial clamping
- Add `validate_canon` helper and invoke it from CLI before running
- Expose `--gamma-type`, `--gamma-beta` and `--gamma-R0` flags for runtime tuning
- Include tests for canonical seeding and validation
- Bump project version references to `4.2.0`

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af8c6dffd08321bafc8130a91fe688