### PR TITLE
Refactor default injection and streamline history export

### DIFF
--- a/src/tnfr/constants.py
+++ b/src/tnfr/constants.py
@@ -182,11 +182,7 @@ DEFAULTS.setdefault("GRAMMAR_CANON", {
 
 def attach_defaults(G, override: bool = False) -> None:
     """Escribe DEFAULTS en G.graph (sin sobreescribir si override=False)."""
-    G.graph.setdefault("_tnfr_defaults_attached", False)
-    for k, v in DEFAULTS.items():
-        if override or k not in G.graph:
-            G.graph[k] = v
-    G.graph["_tnfr_defaults_attached"] = True
+    inject_defaults(G, DEFAULTS, override=override)
 
 
 def inject_defaults(G, defaults: Dict[str, Any] = DEFAULTS, override: bool = False) -> None:

--- a/src/tnfr/metrics.py
+++ b/src/tnfr/metrics.py
@@ -221,11 +221,12 @@ def export_history(G, base_path: str, fmt: str = "csv") -> None:
     """Vuelca glifograma y traza σ(t) a archivos CSV o JSON compactos."""
     hist = _ensure_history(G)
     glifo = glifogram_series(G)
+    sigma_mag = hist.get("sense_sigma_mag", [])
     sigma = {
-        "t": list(range(len(hist.get("sense_sigma_mag", [])))),
+        "t": list(range(len(sigma_mag))),
         "sigma_x": hist.get("sense_sigma_x", []),
         "sigma_y": hist.get("sense_sigma_y", []),
-        "mag": hist.get("sense_sigma_mag", []),
+        "mag": sigma_mag,
         "angle": hist.get("sense_sigma_angle", []),
     }
     fmt = fmt.lower()
@@ -234,8 +235,9 @@ def export_history(G, base_path: str, fmt: str = "csv") -> None:
             writer = csv.writer(f)
             writer.writerow(["t", *GLYPHS_CANONICAL])
             ts = glifo.get("t", [])
+            default_col = [0] * len(ts)
             for i, t in enumerate(ts):
-                row = [t] + [glifo.get(g, [0]*len(ts))[i] for g in GLYPHS_CANONICAL]
+                row = [t] + [glifo.get(g, default_col)[i] for g in GLYPHS_CANONICAL]
                 writer.writerow(row)
         with open(base_path + "_sigma.csv", "w", newline="") as f:
             writer = csv.writer(f)


### PR DESCRIPTION
## Summary
- simplify default attachment by reusing `inject_defaults`
- cache sigma magnitude and default columns to avoid repeated lookups when exporting history

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af9250baa08321b6c0c3bb09b3228e