### PR TITLE
refactor: centralize history helpers and bump version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-# General Project Structure
+# TNFR — Canonical Glyph-Based Dynamics
+
+Reference implementation of the Resonant Fractal Nature Theory (TNFR).
+It models glyph-driven dynamics on NetworkX graphs, providing a modular
+engine to simulate coherent reorganization processes.
+
+## General Project Structure
 
 * **Package entry point.** `__init__.py` registers modules under short names to avoid circular imports and exposes the public API: `preparar_red`, `step`, `run`, and observation utilities.
 

--- a/meta.json
+++ b/meta.json
@@ -27,7 +27,7 @@
   "license": "https://opensource.org/licenses/MIT",
   "url": "https://github.com/fermga/Teoria-de-la-naturaleza-fractal-resonante-TNFR-",
   "datePublished": "2025-05-05",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "isAccessibleForFree": true
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teoria-de-la-naturaleza-fractal-resonante-tnfr",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teoria-de-la-naturaleza-fractal-resonante-tnfr",
-      "version": "4.2.0",
+      "version": "4.3.0",
       "devDependencies": {
         "@remix-run/dev": "^2.17.0",
         "@remix-run/vite": "npm:@remix-run/dev@^2.17.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teoria-de-la-naturaleza-fractal-resonante-tnfr",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,14 +1,14 @@
 [project]
 name = "tnfr"
-version = "4.2.0"
-description = "TNFR canónica: dinámica glífica modular sobre redes."
+version = "4.3.0"
+description = "Canonical TNFR: modular glyph-based dynamics on networks."
 readme = "README.md"
 requires-python = ">=3.9"
 license = { text = "MIT" }
 authors = [{ name = "fmg" }]
 keywords = [
-  "TNFR", "fractal resonante", "resonancia", "glifos",
-  "networkx", "dinámica", "coherencia", "EPI", "Kuramoto"
+  "TNFR", "resonant fractal", "resonance", "glyphs",
+  "networkx", "dynamics", "coherence", "EPI", "Kuramoto"
 ]
 classifiers = [
   "Programming Language :: Python :: 3",

--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -8,7 +8,7 @@ Ecuación nodal:
     ∂EPI/∂t = νf · ΔNFR(t)
 """
 
-__version__ = "4.2.0"
+__version__ = "4.3.0"
 
 # Re-exports de la API pública
 from .dynamics import step, run, set_delta_nfr_hook, validate_canon

--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -23,14 +23,7 @@ import math
 import cmath
 
 from .constants import ALIAS_THETA
-
-
-def _get_attr(nd: Dict[str, Any], aliases, default: float = 0.0) -> float:
-    """Obtiene el primer atributo presente en nd según aliases."""
-    for k in aliases:
-        if k in nd:
-            return nd[k]
-    return default
+from .helpers import _get_attr
 
 
 def kuramoto_R_psi(G) -> Tuple[float, float]:

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -125,6 +125,27 @@ def reciente_glifo(nd: Dict[str, Any], glifo: str, ventana: int) -> bool:
     return False
 
 # -------------------------
+# Utilidades de historial global
+# -------------------------
+
+def ensure_history(G) -> Dict[str, Any]:
+    """Garantiza G.graph['history'] y la devuelve."""
+    if "history" not in G.graph:
+        G.graph["history"] = {}
+    return G.graph["history"]
+
+
+def last_glifo(nd: Dict[str, Any]) -> str | None:
+    """Retorna el glifo más reciente del nodo o ``None``."""
+    hist = nd.get("hist_glifos")
+    if not hist:
+        return None
+    try:
+        return list(hist)[-1]
+    except Exception:
+        return None
+
+# -------------------------
 # Callbacks Γ(R)
 # -------------------------
 

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List, Optional
 from collections import Counter
 
 from .constants import DEFAULTS
-from .helpers import register_callback
+from .helpers import register_callback, ensure_history, last_glifo
 
 try:
     from .gamma import kuramoto_R_psi
@@ -30,22 +30,6 @@ DEFAULTS.setdefault("TRACE", {
 # Helpers
 # -------------------------
 
-def _ensure_history(G):
-    if "history" not in G.graph:
-        G.graph["history"] = {}
-    return G.graph["history"]
-
-
-def _last_glifo(nd: Dict[str, Any]) -> str | None:
-    h = nd.get("hist_glifos")
-    if not h:
-        return None
-    try:
-        return list(h)[-1]
-    except Exception:
-        return None
-
-
 # -------------------------
 # Snapshots
 # -------------------------
@@ -55,7 +39,7 @@ def _trace_before(G, *args, **kwargs):
         return
     cfg = G.graph.get("TRACE", DEFAULTS["TRACE"])
     capture: List[str] = list(cfg.get("capture", []))
-    hist = _ensure_history(G)
+    hist = ensure_history(G)
     key = cfg.get("history_key", "trace_meta")
 
     meta: Dict[str, Any] = {"t": float(G.graph.get("_t", 0.0)), "phase": "before"}
@@ -103,7 +87,7 @@ def _trace_after(G, *args, **kwargs):
         return
     cfg = G.graph.get("TRACE", DEFAULTS["TRACE"])
     capture: List[str] = list(cfg.get("capture", []))
-    hist = _ensure_history(G)
+    hist = ensure_history(G)
     key = cfg.get("history_key", "trace_meta")
 
     meta: Dict[str, Any] = {"t": float(G.graph.get("_t", 0.0)), "phase": "after"}
@@ -119,7 +103,7 @@ def _trace_after(G, *args, **kwargs):
     if "glifo_counts" in capture:
         cnt = Counter()
         for n in G.nodes():
-            g = _last_glifo(G.nodes[n])
+            g = last_glifo(G.nodes[n])
             if g:
                 cnt[g] += 1
         meta["glifos"] = dict(cnt)


### PR DESCRIPTION
## Summary
- centralize history utilities and reuse shared attribute getter
- simplify metrics state handling
- bump project to version 4.3.0 and polish documentation

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af98266e34832193068d6fb64eaac6