### PR TITLE
feat: extend TNFR remesh and metrics

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -28,6 +28,7 @@ from .metrics import (
     latency_series, glifogram_series,
     glyph_top, glyph_dwell_stats, export_history,
 )
+from .operators import aplicar_remesh_red_topologico
 from .trace import register_trace
 from .program import play, seq, block, target, wait, THOL, TARGET, WAIT, ejemplo_canonico_basico
 from .cli import main as cli_main
@@ -53,6 +54,7 @@ __all__ = [
     "latency_series", "glifogram_series",
     "glyph_top", "glyph_dwell_stats",
     "export_history",
+    "aplicar_remesh_red_topologico",
     "play", "seq", "block", "target", "wait", "THOL", "TARGET", "WAIT",
     "cli_main", "build_graph", "get_preset", "NodeState",
     "ejemplo_canonico_basico",

--- a/src/tnfr/constants.py
+++ b/src/tnfr/constants.py
@@ -44,8 +44,9 @@ DEFAULTS: Dict[str, Any] = {
 
 
     # Mezcla para ΔNFR (campo nodal)
-    # phase: dispersión de fase local; epi: gradiente de EPI; vf: desajuste de νf
-    "DNFR_WEIGHTS": {"phase": 0.34, "epi": 0.33, "vf": 0.33},
+    # phase: dispersión de fase local; epi: gradiente de EPI; vf: desajuste de νf;
+    # topo: término topológico (p. ej., centralidad). Pesos se normalizan.
+    "DNFR_WEIGHTS": {"phase": 0.34, "epi": 0.33, "vf": 0.33, "topo": 0.0},
 
     # Índice de sentido Si = α·νf_norm + β·(1 - disp_fase) + γ·(1 - |ΔNFR|/max)
     "SI_WEIGHTS": {"alpha": 0.34, "beta": 0.33, "gamma": 0.33},
@@ -76,7 +77,7 @@ DEFAULTS: Dict[str, Any] = {
     "REMESH_COOLDOWN_VENTANA": 20,    # pasos mínimos entre RE’MESH
     "REMESH_COOLDOWN_TS": 0.0,        # cooldown adicional por tiempo simulado
     # Gating adicional basado en observadores (conmutador + ventana)
-    "REMESH_REQUIRE_STABILITY": False, # si True, exige ventana de estabilidad multi-métrica
+    "REMESH_REQUIRE_STABILITY": True,  # si True, exige ventana de estabilidad multi-métrica
     "REMESH_STABILITY_WINDOW": 25,     # tamaño de ventana para evaluar estabilidad
     "REMESH_MIN_PHASE_SYNC": 0.85,     # media mínima de sincronía de fase en ventana
     "REMESH_MAX_GLYPH_DISR": 0.35,     # media máxima de carga glífica disruptiva en ventana
@@ -91,6 +92,12 @@ DEFAULTS: Dict[str, Any] = {
     "REMESH_TAU_LOCAL": 4,            # pasos hacia atrás (escala local)
     "REMESH_ALPHA": 0.5,              # mezcla con pasado
     "REMESH_ALPHA_HARD": False,       # si True ignora GLYPH_FACTORS['REMESH_alpha']
+
+    # Soporte y norma de la EPI
+    "EPI_SUPPORT_THR": 0.05,          # umbral para Supp(EPI)
+
+    # U'M — compatibilidad mínima para crear/reforzar enlaces funcionales
+    "UM_COMPAT_THRESHOLD": 0.75,
 
     # Histéresis glífica
     "GLYPH_HYSTERESIS_WINDOW": 7,

--- a/tests/test_remesh.py
+++ b/tests/test_remesh.py
@@ -10,6 +10,7 @@ def test_aplicar_remesh_usa_parametro_personalizado():
     G = nx.Graph()
     G.add_node(0)
     attach_defaults(G)
+    G.graph["REMESH_REQUIRE_STABILITY"] = False
 
     # Historial suficiente para el parámetro personalizado
     hist = G.graph.setdefault("history", {})
@@ -33,6 +34,7 @@ def test_remesh_alpha_hard_ignores_glyph_factor():
     G = nx.Graph()
     G.add_node(0)
     attach_defaults(G)
+    G.graph["REMESH_REQUIRE_STABILITY"] = False
     hist = G.graph.setdefault("history", {})
     hist["stable_frac"] = [1.0, 1.0, 1.0]
     tau = G.graph["REMESH_TAU"]


### PR DESCRIPTION
## Summary
- add topological remeshing hook and optional U'M functional links
- track EPI support and morpho-syntactic metrics with history export
- include topological weight in ΔNFR and enable stability gating by default

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b3b00a1694832186186185ad0f1092