### PR TITLE
Implement NA'V convergence and operator terminology

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -138,7 +138,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     if args.summary:
         tg = Tg_global(G, normalize=True)
         lat = latency_series(G)
-        print("Top glifos por Tg:", glyph_top(G, k=5))
+        print("Top operadores por Tg:", glyph_top(G, k=5))
         if lat["value"]:
             print("Latencia media:", sum(lat["value"]) / max(1, len(lat["value"])) )
     return 0

--- a/src/tnfr/constants.py
+++ b/src/tnfr/constants.py
@@ -125,6 +125,7 @@ DEFAULTS: Dict[str, Any] = {
         "THOL_accel": 0.10,     # T’HOL — acelera (seg. deriv.) si hay umbral
         "ZHIR_theta_shift": 1.57079632679,  # Z’HIR — desplazamiento ~π/2
         "NAV_jitter": 0.05,     # NA’V — pequeña inestabilidad creativa
+        "NAV_eta": 0.5,         # NA’V — peso de convergencia hacia νf
         "REMESH_alpha": 0.5,    # RE’MESH — mezcla si no se usa REMESH_ALPHA
     },
 
@@ -133,6 +134,7 @@ DEFAULTS: Dict[str, Any] = {
 
     # Comportamiento NA’V
     "NAV_RANDOM": True,   # si True, usa jitter aleatorio en [-j, j]; si False, jitter determinista por signo
+    "NAV_STRICT": False,  # si True, fuerza ΔNFR ← νf (sin mezcla)
     "RANDOM_SEED": 0,     # semilla base para reproducibilidad del jitter
 
     # Modo ruido para O’Z

--- a/src/tnfr/metrics.py
+++ b/src/tnfr/metrics.py
@@ -202,7 +202,7 @@ def glifogram_series(G) -> Dict[str, List[float]]:
 
 
 def glyph_top(G, k: int = 3) -> List[Tuple[str, float]]:
-    """Top-k glifos por Tg_global (fracción)."""
+    """Top-k operadores estructurales por Tg_global (fracción)."""
     tg = Tg_global(G, normalize=True)
     return sorted(tg.items(), key=lambda kv: kv[1], reverse=True)[:max(1, int(k))]
 

--- a/tests/test_nav.py
+++ b/tests/test_nav.py
@@ -1,0 +1,32 @@
+import networkx as nx
+import pytest
+
+from tnfr.constants import attach_defaults
+from tnfr.operators import op_NAV
+
+
+def test_nav_converges_to_vf_without_jitter():
+    G = nx.Graph()
+    G.add_node(0)
+    attach_defaults(G)
+    nd = G.nodes[0]
+    nd["ΔNFR"] = 0.2
+    nd["νf"] = 1.0
+    G.graph["GLYPH_FACTORS"]["NAV_jitter"] = 0.0
+    op_NAV(G, 0)
+    eta = G.graph["GLYPH_FACTORS"]["NAV_eta"]
+    expected = (1 - eta) * 0.2 + eta * 1.0
+    assert nd["ΔNFR"] == pytest.approx(expected)
+
+
+def test_nav_strict_sets_dnfr_to_vf():
+    G = nx.Graph()
+    G.add_node(0)
+    attach_defaults(G)
+    nd = G.nodes[0]
+    nd["ΔNFR"] = -0.5
+    nd["νf"] = 0.8
+    G.graph["GLYPH_FACTORS"]["NAV_jitter"] = 0.0
+    G.graph["NAV_STRICT"] = True
+    op_NAV(G, 0)
+    assert nd["ΔNFR"] == pytest.approx(0.8)


### PR DESCRIPTION
## Summary
- Make NA'V operator converge ΔNFR toward νf with optional strict mode
- Expose `NAV_eta` and `NAV_STRICT` defaults
- Use "operadores" terminology in CLI and metrics
- Add tests for NA'V convergence behavior

## Testing
- `PYTHONPATH=src python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3c46c38408321af5222826d565f0e