### PR TITLE
feat: adapt vf coherently on stable nodes

### DIFF
--- a/src/tnfr/constants.py
+++ b/src/tnfr/constants.py
@@ -111,7 +111,11 @@ DEFAULTS: Dict[str, Any] = {
     "GLYPH_LOAD_WINDOW": 50,
 
     # Tamaño de ventana para coherencia promedio W̄
-    "WBAR_WINDOW": 25,  
+    "WBAR_WINDOW": 25,
+
+    # Adaptación de frecuencia estructural por coherencia
+    "VF_ADAPT_TAU": 5,   # pasos estables antes de ajustar νf
+    "VF_ADAPT_MU": 0.1,  # velocidad de ajuste hacia la media vecinal
 
     # Factores suaves por glifo (operadores)
     "GLYPH_FACTORS": {

--- a/tests/test_vf_coherencia.py
+++ b/tests/test_vf_coherencia.py
@@ -1,0 +1,27 @@
+import networkx as nx
+import pytest
+
+from tnfr.constants import attach_defaults
+from tnfr.dynamics import step
+
+
+def test_vf_converge_to_neighbor_average_when_stable():
+    G = nx.Graph()
+    G.add_edge(0, 1)
+    attach_defaults(G)
+    # configuraciones para estabilidad
+    G.graph["DNFR_WEIGHTS"] = {"phase": 1.0, "epi": 0.0, "vf": 0.0, "topo": 0.0}
+    G.graph["VF_ADAPT_TAU"] = 2
+    G.graph["VF_ADAPT_MU"] = 0.5
+    for n in G.nodes():
+        nd = G.nodes[n]
+        nd["θ"] = 0.0
+        nd["EPI"] = 0.0
+    G.nodes[0]["νf"] = 0.2
+    G.nodes[1]["νf"] = 1.0
+
+    for _ in range(3):
+        step(G, use_Si=True, apply_glyphs=False)
+
+    assert G.nodes[0]["νf"] == pytest.approx(0.6)
+    assert G.nodes[1]["νf"] == pytest.approx(0.6)


### PR DESCRIPTION
## Summary
- adapt structural frequency toward neighborhood average when nodes remain stable
- track per-node stable counters and expose VF_ADAPT_TAU/MU defaults
- test νf convergence under coherent stability

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3d3fb35dc8321814885cbaa0f971d