### PR TITLE
Add node abstraction, configuration loader and validators

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -26,6 +26,7 @@ from .dynamics import step, _update_history, default_glyph_selector, parametric_
 from .gamma import GAMMA_REGISTRY
 from .scenarios import build_graph
 from .presets import get_preset
+from .config import apply_config
 
 
 def _save_json(path: str, data: Any) -> None:
@@ -91,6 +92,8 @@ def _attach_callbacks(G: nx.Graph) -> None:
 
 def cmd_run(args: argparse.Namespace) -> int:
     G = build_graph(n=args.nodes, topology=args.topology, seed=args.seed)
+    if getattr(args, "config", None):
+        apply_config(G, args.config)
     _attach_callbacks(G)
     validate_canon(G)
     if args.dt is not None:
@@ -152,6 +155,8 @@ def cmd_run(args: argparse.Namespace) -> int:
 
 def cmd_sequence(args: argparse.Namespace) -> int:
     G = build_graph(n=args.nodes, topology=args.topology, seed=args.seed)
+    if getattr(args, "config", None):
+        apply_config(G, args.config)
     _attach_callbacks(G)
     validate_canon(G)
     if args.dt is not None:
@@ -192,6 +197,8 @@ def cmd_sequence(args: argparse.Namespace) -> int:
 
 def cmd_metrics(args: argparse.Namespace) -> int:
     G = build_graph(n=args.nodes, topology=args.topology, seed=args.seed)
+    if getattr(args, "config", None):
+        apply_config(G, args.config)
     _attach_callbacks(G)
     validate_canon(G)
     if args.dt is not None:
@@ -238,6 +245,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     p_run.add_argument("--steps", type=int, default=200)
     p_run.add_argument("--seed", type=int, default=1)
     p_run.add_argument("--preset", type=str, default=None)
+    p_run.add_argument("--config", type=str, default=None)
     p_run.add_argument("--dt", type=float, default=None)
     p_run.add_argument("--integrator", choices=["euler", "rk4"], default=None)
     p_run.add_argument("--save-history", dest="save_history", type=str, default=None)
@@ -266,6 +274,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     p_seq.add_argument("--seed", type=int, default=1)
     p_seq.add_argument("--preset", type=str, default=None)
     p_seq.add_argument("--sequence-file", type=str, default=None)
+    p_seq.add_argument("--config", type=str, default=None)
     p_seq.add_argument("--dt", type=float, default=None)
     p_seq.add_argument("--integrator", choices=["euler", "rk4"], default=None)
     p_seq.add_argument("--save-history", dest="save_history", type=str, default=None)
@@ -299,6 +308,7 @@ def main(argv: Optional[List[str]] = None) -> int:
     p_met.add_argument("--gamma-R0", type=float, default=0.0)
     p_met.add_argument("--remesh-mode", choices=["knn", "mst", "community"], default=None)
     p_met.add_argument("--save", type=str, default=None)
+    p_met.add_argument("--config", type=str, default=None)
     p_met.set_defaults(func=cmd_metrics)
 
     args = p.parse_args(argv)

--- a/src/tnfr/config.py
+++ b/src/tnfr/config.py
@@ -1,0 +1,41 @@
+"""Carga e inyección de configuraciones externas.
+
+Permite definir parámetros en JSON o YAML y aplicarlos sobre ``G.graph``
+reutilizando :func:`tnfr.constants.inject_defaults`.
+"""
+
+from __future__ import annotations
+from typing import Any, Dict
+import json
+
+try:  # pragma: no cover - dependencia opcional
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover
+    yaml = None
+
+from .constants import inject_defaults
+
+
+def load_config(path: str) -> Dict[str, Any]:
+    """Lee un archivo JSON/YAML y devuelve un ``dict`` con los parámetros."""
+    with open(path, "r", encoding="utf-8") as f:
+        text = f.read()
+    if path.endswith((".yaml", ".yml")):
+        if not yaml:  # pragma: no cover - fallo en entorno sin pyyaml
+            raise RuntimeError("pyyaml no está instalado")
+        data = yaml.safe_load(text)
+    else:
+        data = json.loads(text)
+    if not isinstance(data, dict):
+        raise ValueError("El archivo de configuración debe contener un objeto")
+    return data
+
+
+def apply_config(G, path: str) -> None:
+    """Inyecta parámetros desde ``path`` sobre ``G.graph``.
+
+    Se reutiliza :func:`inject_defaults` para mantener la semántica de los
+    *defaults* canónicos.
+    """
+    cfg = load_config(path)
+    inject_defaults(G, cfg, override=True)

--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -673,6 +673,10 @@ def step(G, *, dt: float | None = None, use_Si: bool = True, apply_glyphs: bool 
     # 8) RE’MESH condicionado
     aplicar_remesh_si_estabilizacion_global(G)
 
+    # 8b) Validadores de invariantes
+    from .validators import run_validators
+    run_validators(G)
+
     # Contexto final (últimas métricas del paso)
     h = G.graph.get("history", {})
     ctx = {"step": step_idx}

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+from dataclasses import dataclass, field
+from typing import Deque, Dict, Iterable, List, Optional, Protocol
+from collections import deque
+
+from .constants import DEFAULTS
+from .helpers import push_glifo
+
+
+class NodoProtocol(Protocol):
+    """Protocolo mínimo para nodos TNFR."""
+
+    EPI: float
+    vf: float
+    theta: float
+    Si: float
+    epi_kind: str
+    dnfr: float
+    d2EPI: float
+    graph: Dict[str, object]
+
+    def neighbors(self) -> Iterable["NodoProtocol"]:
+        ...
+
+    def push_glifo(self, glifo: str, window: int) -> None:
+        ...
+
+    def has_edge(self, other: "NodoProtocol") -> bool:
+        ...
+
+    def add_edge(self, other: "NodoProtocol", weight: float) -> None:
+        ...
+
+    def offset(self) -> int:
+        ...
+
+    def all_nodes(self) -> Iterable["NodoProtocol"]:
+        ...
+
+
+@dataclass
+class NodoTNFR:
+    """Representa un nodo TNFR autónomo."""
+
+    EPI: float = 0.0
+    vf: float = 0.0
+    theta: float = 0.0
+    Si: float = 0.0
+    epi_kind: str = ""
+    dnfr: float = 0.0
+    d2EPI: float = 0.0
+    graph: Dict[str, object] = field(default_factory=dict)
+    _neighbors: List["NodoTNFR"] = field(default_factory=list)
+    _hist_glifos: Deque[str] = field(default_factory=lambda: deque(maxlen=DEFAULTS.get("GLYPH_HYSTERESIS_WINDOW", 7)))
+
+    def neighbors(self) -> Iterable["NodoTNFR"]:
+        return list(self._neighbors)
+
+    def has_edge(self, other: "NodoTNFR") -> bool:
+        return other in self._neighbors
+
+    def add_edge(self, other: "NodoTNFR", weight: float = 1.0) -> None:
+        if other not in self._neighbors:
+            self._neighbors.append(other)
+            other._neighbors.append(self)
+
+    def push_glifo(self, glifo: str, window: int) -> None:
+        self._hist_glifos.append(glifo)
+        while len(self._hist_glifos) > window:
+            self._hist_glifos.popleft()
+        self.epi_kind = glifo
+
+    def offset(self) -> int:
+        return 0
+
+    def all_nodes(self) -> Iterable["NodoTNFR"]:
+        return list(getattr(self.graph, "_all_nodes", [self]))
+
+    def aplicar_glifo(self, glifo: str, window: Optional[int] = None) -> None:
+        from .operators import aplicar_glifo_obj
+        aplicar_glifo_obj(self, glifo, window=window)
+
+    def integrar(self, dt: float) -> None:
+        self.EPI += self.dnfr * dt
+
+
+class NodoNX(NodoProtocol):
+    """Adaptador para nodos ``networkx``."""
+
+    def __init__(self, G, n):
+        self.G = G
+        self.n = n
+        self.graph = G.graph
+
+    @property
+    def EPI(self) -> float:
+        from .helpers import _get_attr
+        from .constants import ALIAS_EPI
+        return float(_get_attr(self.G.nodes[self.n], ALIAS_EPI, 0.0))
+
+    @EPI.setter
+    def EPI(self, v: float) -> None:
+        from .helpers import _set_attr
+        from .constants import ALIAS_EPI
+        _set_attr(self.G.nodes[self.n], ALIAS_EPI, float(v))
+
+    @property
+    def vf(self) -> float:
+        from .helpers import _get_attr
+        from .constants import ALIAS_VF
+        return float(_get_attr(self.G.nodes[self.n], ALIAS_VF, 0.0))
+
+    @vf.setter
+    def vf(self, v: float) -> None:
+        from .helpers import _set_attr
+        from .constants import ALIAS_VF
+        _set_attr(self.G.nodes[self.n], ALIAS_VF, float(v))
+
+    @property
+    def theta(self) -> float:
+        from .helpers import _get_attr
+        from .constants import ALIAS_THETA
+        return float(_get_attr(self.G.nodes[self.n], ALIAS_THETA, 0.0))
+
+    @theta.setter
+    def theta(self, v: float) -> None:
+        from .helpers import _set_attr
+        from .constants import ALIAS_THETA
+        _set_attr(self.G.nodes[self.n], ALIAS_THETA, float(v))
+
+    @property
+    def Si(self) -> float:
+        from .helpers import _get_attr
+        from .constants import ALIAS_SI
+        return float(_get_attr(self.G.nodes[self.n], ALIAS_SI, 0.0))
+
+    @Si.setter
+    def Si(self, v: float) -> None:
+        from .helpers import _set_attr
+        from .constants import ALIAS_SI
+        _set_attr(self.G.nodes[self.n], ALIAS_SI, float(v))
+
+    @property
+    def epi_kind(self) -> str:
+        from .helpers import _get_attr_str
+        from .constants import ALIAS_EPI_KIND
+        return _get_attr_str(self.G.nodes[self.n], ALIAS_EPI_KIND, "")
+
+    @epi_kind.setter
+    def epi_kind(self, v: str) -> None:
+        from .helpers import _set_attr_str
+        from .constants import ALIAS_EPI_KIND
+        _set_attr_str(self.G.nodes[self.n], ALIAS_EPI_KIND, str(v))
+
+    @property
+    def dnfr(self) -> float:
+        from .helpers import _get_attr
+        from .constants import ALIAS_DNFR
+        return float(_get_attr(self.G.nodes[self.n], ALIAS_DNFR, 0.0))
+
+    @dnfr.setter
+    def dnfr(self, v: float) -> None:
+        from .helpers import _set_attr
+        from .constants import ALIAS_DNFR
+        _set_attr(self.G.nodes[self.n], ALIAS_DNFR, float(v))
+
+    @property
+    def d2EPI(self) -> float:
+        from .helpers import _get_attr
+        from .constants import ALIAS_D2EPI
+        return float(_get_attr(self.G.nodes[self.n], ALIAS_D2EPI, 0.0))
+
+    @d2EPI.setter
+    def d2EPI(self, v: float) -> None:
+        from .helpers import _set_attr
+        from .constants import ALIAS_D2EPI
+        _set_attr(self.G.nodes[self.n], ALIAS_D2EPI, float(v))
+
+    def neighbors(self) -> Iterable[NodoProtocol]:
+        return [NodoNX(self.G, v) for v in self.G.neighbors(self.n)]
+
+    def push_glifo(self, glifo: str, window: int) -> None:
+        push_glifo(self.G.nodes[self.n], glifo, window)
+        self.epi_kind = glifo
+
+    def has_edge(self, other: NodoProtocol) -> bool:
+        if isinstance(other, NodoNX):
+            return self.G.has_edge(self.n, other.n)
+        raise NotImplementedError
+
+    def add_edge(self, other: NodoProtocol, weight: float) -> None:
+        if isinstance(other, NodoNX):
+            self.G.add_edge(self.n, other.n, weight=float(weight))
+        else:
+            raise NotImplementedError
+
+    def offset(self) -> int:
+        from .operators import _node_offset
+        return _node_offset(self.G, self.n)
+
+    def all_nodes(self) -> Iterable[NodoProtocol]:
+        return [NodoNX(self.G, v) for v in self.G.nodes()]

--- a/src/tnfr/validators.py
+++ b/src/tnfr/validators.py
@@ -1,0 +1,38 @@
+"""Validadores de invariantes TNFR."""
+
+from __future__ import annotations
+from typing import Iterable
+
+from .constants import ALIAS_EPI, DEFAULTS
+from .helpers import _get_attr
+from .sense import sigma_vector_global, GLYPHS_CANONICAL
+from .helpers import last_glifo
+
+
+def _validate_epi(G) -> None:
+    emin = float(G.graph.get("EPI_MIN", DEFAULTS.get("EPI_MIN", -1.0)))
+    emax = float(G.graph.get("EPI_MAX", DEFAULTS.get("EPI_MAX", 1.0)))
+    for n in G.nodes():
+        x = float(_get_attr(G.nodes[n], ALIAS_EPI, 0.0))
+        if not (emin - 1e-9 <= x <= emax + 1e-9):
+            raise ValueError(f"EPI fuera de rango en nodo {n}: {x}")
+
+
+def _validate_sigma(G) -> None:
+    sv = sigma_vector_global(G)
+    if sv.get("mag", 0.0) > 1.0 + 1e-9:
+        raise ValueError("Norma de σ excede 1")
+
+
+def _validate_glifos(G) -> None:
+    for n in G.nodes():
+        g = last_glifo(G.nodes[n])
+        if g and g not in GLYPHS_CANONICAL:
+            raise ValueError(f"Glifo inválido {g} en nodo {n}")
+
+
+def run_validators(G) -> None:
+    """Ejecuta todos los validadores de invariantes sobre ``G``."""
+    _validate_epi(G)
+    _validate_sigma(G)
+    _validate_glifos(G)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,38 @@
+import pytest
+from tnfr.scenarios import build_graph
+from tnfr.constants import inject_defaults, DEFAULTS, ALIAS_EPI_KIND, ALIAS_EPI
+from tnfr.validators import run_validators
+from tnfr.helpers import _set_attr_str, _set_attr
+
+
+def _base_graph():
+    G = build_graph(n=4, topology="ring", seed=1)
+    inject_defaults(G, DEFAULTS)
+    return G
+
+
+def test_validator_epi_range():
+    G = _base_graph()
+    n0 = list(G.nodes())[0]
+    _set_attr(G.nodes[n0], ALIAS_EPI, 2.0)
+    with pytest.raises(ValueError):
+        run_validators(G)
+
+
+def test_validator_sigma_norm(monkeypatch):
+    G = _base_graph()
+
+    def fake_sigma(G):
+        return {"mag": 1.5}
+
+    monkeypatch.setattr("tnfr.validators.sigma_vector_global", fake_sigma)
+    with pytest.raises(ValueError):
+        run_validators(G)
+
+
+def test_validator_glifo_invalido():
+    G = _base_graph()
+    n0 = list(G.nodes())[0]
+    _set_attr_str(G.nodes[n0], ALIAS_EPI_KIND, "INVALID")
+    with pytest.raises(ValueError):
+        run_validators(G)


### PR DESCRIPTION
## Summary
- Introduce `NodoTNFR` class and `NodoNX` adapter so operators work on node instances
- Allow loading JSON/YAML configs into graphs and expose via `--config`
- Validate invariants (EPI bounds, sigma norm, glyph validity) during `step`

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3d885326c8321b514a3534b558959