### PR TITLE
fix: simplify prev history lookup

### DIFF
--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -113,8 +113,8 @@ def enforce_canonical_grammar(G, n, cand: str) -> str:
     hist = nd.get("hist_glifos")
     if hist:
         try:
-            prev = list(hist)[-1]
-        except Exception:
+            prev = hist[-1]
+        except IndexError:
             prev = None
     if prev in CANON_COMPAT and cand not in CANON_COMPAT[prev]:
         cand = CANON_FALLBACK.get(prev, cand)


### PR DESCRIPTION
## Summary
- simplify previous glyph retrieval using direct index access
- catch IndexError when history is empty to keep grammar enforcement robust

## Testing
- `PYTHONPATH=src pytest -c /tmp/pytest_empty.ini`


------
https://chatgpt.com/codex/tasks/task_e_68b42ccd71bc83218722cacc9b860e5d