### PR TITLE
Ensure glyph history window is respected

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -125,7 +125,10 @@ def fase_media(G, n) -> float:
 
 def push_glifo(nd: Dict[str, Any], glifo: str, window: int) -> None:
     """Añade ``glifo`` al historial del nodo con tamaño máximo ``window``."""
-    hist = nd.setdefault("hist_glifos", deque(maxlen=window))
+    hist = nd.get("hist_glifos")
+    if hist is None or hist.maxlen != window:
+        hist = deque(hist or [], maxlen=window)
+        nd["hist_glifos"] = hist
     hist.append(str(glifo))
 
 

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -65,9 +65,9 @@ class NodoTNFR:
             other._neighbors.append(self)
 
     def push_glifo(self, glifo: str, window: int) -> None:
+        if self._hist_glifos.maxlen != window:
+            self._hist_glifos = deque(self._hist_glifos, maxlen=window)
         self._hist_glifos.append(glifo)
-        while len(self._hist_glifos) > window:
-            self._hist_glifos.popleft()
         self.epi_kind = glifo
 
     def offset(self) -> int:


### PR DESCRIPTION
## Summary
- Adjust `NodoTNFR.push_glifo` to resize deque instead of manual trimming, honoring dynamic history windows
- Rework helper `push_glifo` to recreate deque when window changes so various node types respect the specified window

## Testing
- `PYTHONPATH=src pytest -q -c /tmp/pytest.ini`

------
https://chatgpt.com/codex/tasks/task_e_68b434d4010c83218c17ad3be3500397