### PR TITLE
Refactor observers statistics import

### DIFF
--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from collections import Counter
 from typing import Dict, Any
 import math
+import statistics as st
 
 from .constants import ALIAS_DNFR, ALIAS_EPI, ALIAS_THETA, ALIAS_dEPI
 from .helpers import _get_attr, list_mean, register_callback
@@ -50,7 +51,6 @@ def sincronía_fase(G) -> float:
         return 1.0
     th = math.atan2(sum(Y) / len(Y), sum(X) / len(X))
     # varianza angular aproximada (0 = muy sincronizado)
-    import statistics as st
     var = (
         st.pvariance(
             [


### PR DESCRIPTION
## Summary
- hoist `statistics` import to observers module header
- remove redundant import from `sincronía_fase`

## Testing
- `PYTHONPATH=src pytest -q -c /dev/null tests/test_history_series.py::test_history_delta_si_and_B`
- `PYTHONPATH=src pytest -q -c /dev/null tests/test_vf_coherencia.py::test_vf_converge_to_neighbor_average_when_stable`


------
https://chatgpt.com/codex/tasks/task_e_68b4387dc2d8832193831aa1d592ef3e