### PR TITLE
Ensure EN sets epi_kind for isolated nodes

### DIFF
--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -78,6 +78,8 @@ def _op_EN(node: NodoProtocol) -> None:  # E’N — Recepción
     epi = node.EPI
     neigh = list(node.neighbors())
     if not neigh:
+        # Aunque no haya vecinos, etiquetar el nodo con el glifo E’N
+        node.epi_kind = "E’N"
         return
     epi_bar = list_mean(v.EPI for v in neigh)
     node.EPI = (1 - mix) * epi + mix * epi_bar

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,6 +1,7 @@
 import pytest
 import networkx as nx
-import pytest
+from tnfr.node import NodoTNFR
+from tnfr.operators import op_EN
 
 from tnfr.dynamics import default_compute_delta_nfr, update_epi_via_nodal_equation
 
@@ -37,3 +38,10 @@ def test_dnfr_weights_normalization():
     assert pytest.approx(weights["phase"], rel=1e-6) == 1/3
     assert pytest.approx(weights["epi"], rel=1e-6) == 1/3
     assert pytest.approx(weights["vf"], rel=1e-6) == 1/3
+
+
+def test_op_en_sets_epi_kind_on_isolated_node():
+    node = NodoTNFR(EPI=1.0)
+    op_EN(node)
+    assert node.EPI == 1.0
+    assert node.epi_kind == "E’N"


### PR DESCRIPTION
## Summary
- Ensure `_op_EN` marks isolated nodes with `E’N`
- Add regression test for isolated node behavior

## Testing
- `PYTHONPATH=src python -m pytest -q -c /tmp/pytest.ini`


------
https://chatgpt.com/codex/tasks/task_e_68b43a50322c8321ad50beb32b979a1f