### PR TITLE
Use math constant for ZHIR theta shift

### DIFF
--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -164,7 +164,7 @@ def _op_THOL(node: NodoProtocol) -> None:  # T’HOL — Autoorganización
 
 
 def _op_ZHIR(node: NodoProtocol) -> None:  # Z’HIR — Mutación
-    shift = float(node.graph.get("GLYPH_FACTORS", DEFAULTS["GLYPH_FACTORS"]).get("ZHIR_theta_shift", 1.57079632679))
+    shift = float(node.graph.get("GLYPH_FACTORS", DEFAULTS["GLYPH_FACTORS"]).get("ZHIR_theta_shift", math.pi / 2))
     node.theta = node.theta + shift
 
 


### PR DESCRIPTION
## Summary
- Replace numeric default for ZHIR theta shift with `math.pi / 2`
- Confirm `math` import remains present

## Testing
- `PYTHONPATH=src pytest -q -c=/dev/null`

------
https://chatgpt.com/codex/tasks/task_e_68b43ddff70c8321baf4a7a3c71e407f