### PR TITLE
feat: add angle diff helper and refactor usage

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -32,7 +32,7 @@ from .constants import (
 )
 from .gamma import eval_gamma
 from .helpers import (
-     clamp, clamp01, list_mean, phase_distance,
+     clamp, clamp01, list_mean, phase_distance, angle_diff,
      _get_attr, _set_attr, _get_attr_str, _set_attr_str, media_vecinal, fase_media,
      invoke_callbacks, reciente_glifo
 )
@@ -93,7 +93,7 @@ def default_compute_delta_nfr(G) -> None:
         th_i = _get_attr(nd, ALIAS_THETA, 0.0)
         th_bar = fase_media(G, n)
         # Gradiente de fase: empuja hacia la fase media (signo envuelto)
-        g_phase = -((th_i - th_bar + math.pi) % (2 * math.pi) - math.pi) / math.pi  # ~[-1,1]
+        g_phase = -angle_diff(th_i, th_bar) / math.pi  # ~[-1,1]
 
         epi_i = _get_attr(nd, ALIAS_EPI, 0.0)
         epi_bar = media_vecinal(G, n, ALIAS_EPI, default=epi_i)
@@ -130,7 +130,7 @@ def dnfr_phase_only(G) -> None:
         nd = G.nodes[n]
         th_i = _get_attr(nd, ALIAS_THETA, 0.0)
         th_bar = fase_media(G, n)
-        g_phase = -((th_i - th_bar + math.pi) % (2 * math.pi) - math.pi) / math.pi
+        g_phase = -angle_diff(th_i, th_bar) / math.pi
         _set_attr(nd, ALIAS_DNFR, g_phase)
     _write_dnfr_metadata(G, weights={"phase": 1.0}, hook_name="dnfr_phase_only", note="Hook de ejemplo.")
 
@@ -414,8 +414,8 @@ def coordinar_fase_global_vecinal(G, fuerza_global: float | None = None, fuerza_
         nd = G.nodes[n]
         th = _get_attr(nd, ALIAS_THETA, 0.0)
         thL = fase_media(G, n)
-        dG = ((thG - th + math.pi) % (2*math.pi) - math.pi)
-        dL = ((thL - th + math.pi) % (2*math.pi) - math.pi)
+        dG = angle_diff(thG, th)
+        dL = angle_diff(thL, th)
         _set_attr(nd, ALIAS_THETA, th + kG*dG + kL*dL)
 
 # -------------------------

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -52,6 +52,11 @@ def _wrap_angle(a: float) -> float:
     return a
 
 
+def angle_diff(a: float, b: float) -> float:
+    """Diferencia mínima entre ``a`` y ``b`` en (-π, π]."""
+    return _wrap_angle(a - b)
+
+
 def phase_distance(a: float, b: float) -> float:
     """Distancia de fase normalizada en [0,1]. 0 = misma fase, 1 = opuesta."""
     return abs(_wrap_angle(a - b)) / math.pi

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -10,7 +10,7 @@ import math
 import statistics as st
 
 from .constants import ALIAS_DNFR, ALIAS_EPI, ALIAS_THETA, ALIAS_dEPI
-from .helpers import _get_attr, list_mean, register_callback
+from .helpers import _get_attr, list_mean, register_callback, angle_diff
 
 # -------------------------
 # Observador estándar Γ(R)
@@ -54,11 +54,7 @@ def sincronía_fase(G) -> float:
     var = (
         st.pvariance(
             [
-                (
-                    (_get_attr(G.nodes[n], ALIAS_THETA, 0.0) - th + math.pi)
-                    % (2 * math.pi)
-                    - math.pi
-                )
+                angle_diff(_get_attr(G.nodes[n], ALIAS_THETA, 0.0), th)
                 for n in G.nodes()
             ]
         )

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -13,6 +13,7 @@ from .helpers import (
     clamp01,
     list_mean,
     invoke_callbacks,
+    angle_diff,
     _get_attr,
     _set_attr,
     _get_attr_str,
@@ -118,7 +119,7 @@ def _op_UM(node: NodoProtocol) -> None:  # U’M — Acoplamiento
     k = float(gf.get("UM_theta_push", 0.25))
     th = node.theta
     thL = _fase_media_node(node)
-    d = ((thL - th + math.pi) % (2 * math.pi) - math.pi)
+    d = angle_diff(thL, th)
     node.theta = th + k * d
 
     if bool(node.graph.get("UM_FUNCTIONAL_LINKS", False)):
@@ -129,7 +130,7 @@ def _op_UM(node: NodoProtocol) -> None:  # U’M — Acoplamiento
             if j is node or node.has_edge(j):
                 continue
             th_j = j.theta
-            dphi = abs(((th_j - th + math.pi) % (2 * math.pi)) - math.pi) / math.pi
+            dphi = abs(angle_diff(th_j, th)) / math.pi
             epi_j = j.EPI
             si_j = j.Si
             epi_sim = 1.0 - abs(epi_i - epi_j) / (abs(epi_i) + abs(epi_j) + 1e-9)


### PR DESCRIPTION
## Summary
- expose public `angle_diff` for wrapped angle difference
- reuse `angle_diff` across dynamics, observers and operators

## Testing
- `PYTHONPATH=src pytest -c /dev/null`


------
https://chatgpt.com/codex/tasks/task_e_68b4495b6318832185d3f2beae3bde9f