### PR TITLE
Clarify REMESH_TAU alias

### DIFF
--- a/src/tnfr/constants.py
+++ b/src/tnfr/constants.py
@@ -91,7 +91,6 @@ DEFAULTS: Dict[str, Any] = {
     "REMESH_COMMUNITY_K": 2,          # conexiones por comunidad
 
     # RE’MESH: memoria τ y mezcla α (global/local)
-    "REMESH_TAU": 8,                  # compatibilidad: tau global por defecto
     "REMESH_TAU_GLOBAL": 8,           # pasos hacia atrás (escala global)
     "REMESH_TAU_LOCAL": 4,            # pasos hacia atrás (escala local)
     "REMESH_ALPHA": 0.5,              # mezcla con pasado
@@ -184,6 +183,9 @@ DEFAULTS: Dict[str, Any] = {
     "CALLBACKS_STRICT": False,  # si True, un error en callback detiene; si False, se loguea y continúa
     "VALIDATORS_STRICT": False, # si True, alerta si se clampa fuera de rango
 }
+
+# Retrocompatibilidad: alias deprecado
+DEFAULTS["REMESH_TAU"] = DEFAULTS["REMESH_TAU_GLOBAL"]
 
 # Gramática glífica canónica
 DEFAULTS.setdefault("GRAMMAR_CANON", {

--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -669,8 +669,19 @@ def step(G, *, dt: float | None = None, use_Si: bool = True, apply_glyphs: bool 
     # 7) Observadores ligeros
     _update_history(G)
     # dynamics.py — dentro de step(), justo antes del punto 8)
-    tau_g = int(G.graph.get("REMESH_TAU_GLOBAL", G.graph.get("REMESH_TAU", DEFAULTS["REMESH_TAU_GLOBAL"])))
-    tau_l = int(G.graph.get("REMESH_TAU_LOCAL", G.graph.get("REMESH_TAU", DEFAULTS["REMESH_TAU_LOCAL"])))
+    # REMESH_TAU: alias legado de REMESH_TAU_GLOBAL
+    tau_g = int(
+        G.graph.get(
+            "REMESH_TAU_GLOBAL",
+            G.graph.get("REMESH_TAU", DEFAULTS["REMESH_TAU_GLOBAL"]),
+        )
+    )
+    tau_l = int(
+        G.graph.get(
+            "REMESH_TAU_LOCAL",
+            G.graph.get("REMESH_TAU", DEFAULTS["REMESH_TAU_LOCAL"]),
+        )
+    )
     tau = max(tau_g, tau_l)
     maxlen = max(2 * tau + 5, 64)
     epi_hist = G.graph.get("_epi_hist")

--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -44,7 +44,13 @@ def preparar_red(G: nx.Graph, *, override_defaults: bool = False, **overrides) -
         "phase_R": [], 
         "phase_disr": [],
     })
-    tau = int(G.graph.get("REMESH_TAU", DEFAULTS["REMESH_TAU"]))
+    # REMESH_TAU: alias legado de REMESH_TAU_GLOBAL
+    tau = int(
+        G.graph.get(
+            "REMESH_TAU_GLOBAL",
+            G.graph.get("REMESH_TAU", DEFAULTS["REMESH_TAU_GLOBAL"]),
+        )
+    )
     maxlen = max(2 * tau + 5, 64)
     G.graph.setdefault("_epi_hist", deque(maxlen=maxlen))
     # Auto-attach del observador estándar si se pide

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -283,8 +283,19 @@ def _remesh_alpha_info(G):
 
 def aplicar_remesh_red(G) -> None:
     """RE’MESH a escala de red usando _epi_hist con memoria multi-escala."""
-    tau_g = int(G.graph.get("REMESH_TAU_GLOBAL", G.graph.get("REMESH_TAU", DEFAULTS["REMESH_TAU_GLOBAL"])))
-    tau_l = int(G.graph.get("REMESH_TAU_LOCAL", G.graph.get("REMESH_TAU", DEFAULTS["REMESH_TAU_LOCAL"])))
+    # REMESH_TAU: alias legado de REMESH_TAU_GLOBAL
+    tau_g = int(
+        G.graph.get(
+            "REMESH_TAU_GLOBAL",
+            G.graph.get("REMESH_TAU", DEFAULTS["REMESH_TAU_GLOBAL"]),
+        )
+    )
+    tau_l = int(
+        G.graph.get(
+            "REMESH_TAU_LOCAL",
+            G.graph.get("REMESH_TAU", DEFAULTS["REMESH_TAU_LOCAL"]),
+        )
+    )
     tau_req = max(tau_g, tau_l)
     alpha, alpha_src = _remesh_alpha_info(G)
     G.graph["_REMESH_ALPHA_SRC"] = alpha_src

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -69,10 +69,10 @@ def test_remesh_cooldown_if_present(G_small):
     w_estab = int(G_small.graph.get("REMESH_STABILITY_WINDOW", 0))
     sf = G_small.graph.setdefault("history", {}).setdefault("stable_frac", [])
     sf.extend([1.0] * w_estab)
-    tau = int(G_small.graph.get("REMESH_TAU", 0))
+    tau_g = int(G_small.graph.get("REMESH_TAU_GLOBAL", 0))
     snap = {n: G_small.nodes[n].get("EPI", 0.0) for n in G_small.nodes()}
     from collections import deque
-    G_small.graph["_epi_hist"] = deque([snap.copy() for _ in range(tau + 1)], maxlen=tau + 1)
+    G_small.graph["_epi_hist"] = deque([snap.copy() for _ in range(tau_g + 1)], maxlen=tau_g + 1)
 
     aplicar_remesh_si_estabilizacion_global(G_small)
     events = list(G_small.graph.get("history", {}).get("remesh_events", []))

--- a/tests/test_remesh.py
+++ b/tests/test_remesh.py
@@ -17,7 +17,7 @@ def test_aplicar_remesh_usa_parametro_personalizado():
     hist["stable_frac"] = [1.0, 1.0, 1.0]
 
     # Historial de EPI necesario para aplicar_remesh_red
-    tau = G.graph["REMESH_TAU"]
+    tau = G.graph["REMESH_TAU_GLOBAL"]
     maxlen = max(2 * tau + 5, 64)
     G.graph["_epi_hist"] = deque([{0: 0.0} for _ in range(tau + 1)], maxlen=maxlen)
 
@@ -37,7 +37,7 @@ def test_remesh_alpha_hard_ignores_glyph_factor():
     G.graph["REMESH_REQUIRE_STABILITY"] = False
     hist = G.graph.setdefault("history", {})
     hist["stable_frac"] = [1.0, 1.0, 1.0]
-    tau = G.graph["REMESH_TAU"]
+    tau = G.graph["REMESH_TAU_GLOBAL"]
     maxlen = max(2 * tau + 5, 64)
     G.graph["_epi_hist"] = deque([{0: 0.0} for _ in range(tau + 1)], maxlen=maxlen)
     G.graph["REMESH_ALPHA"] = 0.7


### PR DESCRIPTION
## Summary
- drop standalone `REMESH_TAU` from defaults and expose it as a deprecated alias to `REMESH_TAU_GLOBAL`
- document alias in remesh routines and initializer
- switch tests to use `REMESH_TAU_GLOBAL`

## Testing
- `pip install networkx`
- `PYTHONPATH=src pytest tests/test_invariants.py tests/test_remesh.py`


------
https://chatgpt.com/codex/tasks/task_e_68b44dee89d08321aacc5a4612247f6b