### PR TITLE
cache delta NFR weights

### DIFF
--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -35,9 +35,11 @@ def test_dnfr_weights_normalization():
     G.graph["DNFR_WEIGHTS"] = {"phase": -1, "epi": -1, "vf": -1}
     default_compute_delta_nfr(G)
     weights = G.graph["_DNFR_META"]["weights_norm"]
+    cache = G.graph.get("_dnfr_weights")
     assert pytest.approx(weights["phase"], rel=1e-6) == 1/3
     assert pytest.approx(weights["epi"], rel=1e-6) == 1/3
     assert pytest.approx(weights["vf"], rel=1e-6) == 1/3
+    assert cache == weights
 
 
 def test_op_en_sets_epi_kind_on_isolated_node():


### PR DESCRIPTION
## Summary
- cache normalized ΔNFR weights in the graph
- reuse cached weights in default ΔNFR computation
- test ΔNFR weight caching

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b44f299b908321bf4ed3b4f3c40b06