### PR TITLE
Align version numbers across Python and Node

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,15 @@ Requires **Python ≥ 3.9**.
 
 ---
 
+## Versioning
+
+The Python package (`pyproject.toml`) and the Node package (`package.json`) share a
+unified version number. Releases follow [Semantic Versioning](https://semver.org/)
+compatible with [PEP 440](https://peps.python.org/pep-0440/). Ensure both files are
+updated together.
+
+---
+
 ## Contributing
 
 Suggestions, issues, and PRs are welcome. Guidelines:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "teoria-de-la-naturaleza-fractal-resonante-tnfr",
-  "version": "4.3.0",
+  "version": "4.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "teoria-de-la-naturaleza-fractal-resonante-tnfr",
-      "version": "4.3.0",
+      "version": "4.5.2",
       "devDependencies": {
         "@remix-run/dev": "^2.17.0",
         "@remix-run/vite": "npm:@remix-run/dev@^2.17.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teoria-de-la-naturaleza-fractal-resonante-tnfr",
-  "version": "4.3.0",
+  "version": "4.5.2",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,7 @@
 [project]
 name = "tnfr"
+# Versioning follows PEP 440 / Semantic Versioning and should stay
+# in sync with package.json.
 version = "4.5.2"
 description = "Modular structural-based dynamics on networks."
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Sync package.json version with pyproject.toml
- Document versioning scheme in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b45002405c8321ac0be5b77f712ba1