### PR TITLE
cache node offset mapping for deterministic jitter

### DIFF
--- a/src/tnfr/constants.py
+++ b/src/tnfr/constants.py
@@ -255,6 +255,13 @@ def inject_defaults(G, defaults: Dict[str, Any] = DEFAULTS, override: bool = Fal
         if override or k not in G.graph:
             G.graph[k] = v
     G.graph["_tnfr_defaults_attached"] = True
+    # Prepare deterministic node offset mapping once defaults are attached.
+    try:  # local import to avoid circular dependency at module import time
+        from .operators import _ensure_node_offset_map
+
+        _ensure_node_offset_map(G)
+    except Exception:
+        pass
 
 
 def merge_overrides(G, **overrides) -> None:


### PR DESCRIPTION
## Summary
- add `_ensure_node_offset_map` to cache deterministic node ordering
- reuse cached mapping in `_node_offset` and `random_jitter`
- initialize mapping when defaults are attached to a graph

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b45578802c8321a191508023a24181