### PR TITLE
Cache global maxima for Si computation

### DIFF
--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -19,6 +19,8 @@ from .helpers import (
     _get_attr_str,
     _set_attr,
     _set_attr_str,
+    set_vf,
+    set_dnfr,
 )
 
 
@@ -121,7 +123,7 @@ class NodoNX(NodoProtocol):
 
     @vf.setter
     def vf(self, v: float) -> None:
-        _set_attr(self.G.nodes[self.n], ALIAS_VF, float(v))
+        set_vf(self.G, self.n, float(v))
 
     @property
     def theta(self) -> float:
@@ -153,7 +155,7 @@ class NodoNX(NodoProtocol):
 
     @dnfr.setter
     def dnfr(self, v: float) -> None:
-        _set_attr(self.G.nodes[self.n], ALIAS_DNFR, float(v))
+        set_dnfr(self.G, self.n, float(v))
 
     @property
     def d2EPI(self) -> float:


### PR DESCRIPTION
## Summary
- cache global maxima of νf and ΔNFR in graph and update incrementally
- reuse cached maxima when computing Si
- route νf and ΔNFR updates through new setters to keep caches in sync

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b45683f6808321b524f59437c1fee2