### PR TITLE
refactor: use ensure_history in standard observer

### DIFF
--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -10,14 +10,14 @@ import math
 import statistics as st
 
 from .constants import ALIAS_DNFR, ALIAS_EPI, ALIAS_THETA, ALIAS_dEPI
-from .helpers import _get_attr, list_mean, register_callback, angle_diff
+from .helpers import _get_attr, list_mean, register_callback, angle_diff, ensure_history
 
 # -------------------------
 # Observador estándar Γ(R)
 # -------------------------
 def _std_log(G, kind: str, ctx: dict):
     """Guarda eventos compactos en history['events']."""
-    h = G.graph.setdefault("history", {})
+    h = ensure_history(G)
     h.setdefault("events", []).append((kind, dict(ctx)))
 
 def std_before(G, ctx):


### PR DESCRIPTION
## Summary
- ensure history initialization via `ensure_history` in `_std_log`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b45aaf75848321b4cfa0a9982f6128