### PR TITLE
refactor: move math import to module level

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -859,7 +859,6 @@ def _update_history(G) -> None:
   
     # --- nuevas series: Si agregado (media y colas) ---
     try:
-        import math
         sis = []
         for n in G.nodes():
             sis.append(_get_attr(G.nodes[n], ALIAS_SI, float("nan")))


### PR DESCRIPTION
## Summary
- move `math` import to the module-level import block in `dynamics`

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b45ef0e568832193d3a4c2564ddaa0