### PR TITLE
Avoid deque copy when counting recent glyphs

### DIFF
--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -8,6 +8,7 @@ from collections import Counter
 from typing import Dict, Any
 import math
 import statistics as st
+from itertools import islice
 
 from .constants import ALIAS_DNFR, ALIAS_EPI, ALIAS_THETA, ALIAS_dEPI
 from .helpers import _get_attr, list_mean, register_callback, angle_diff, ensure_history
@@ -83,10 +84,12 @@ def carga_glifica(G, window: int | None = None) -> dict:
         hist = nd.get("hist_glifos")
         if not hist:
             continue
-        seq = list(hist)
         if window is not None and window > 0:
-            seq = seq[-window:]
-        total.update(seq)
+            start = max(len(hist) - window, 0)
+            seq_iter = islice(hist, start, None)
+        else:
+            seq_iter = hist
+        total.update(seq_iter)
 
 
     count = sum(total.values())


### PR DESCRIPTION
## Summary
- Iterate over `hist_glifos` using `itertools.islice` to limit history without copying the deque
- Import `islice` for efficient glyph counting

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b461966f7c8321a603132c8dbb9181