### PR TITLE
Protect alias cache with lock

### DIFF
--- a/tests/test_alias_lookup_threadsafe.py
+++ b/tests/test_alias_lookup_threadsafe.py
@@ -1,0 +1,17 @@
+from concurrent.futures import ThreadPoolExecutor
+
+from tnfr.helpers import alias_lookup, _alias_cache, _ALIAS_CACHE_MAX
+
+
+def _worker(i):
+    d = {}
+    aliases = [f"k{i}", f"a{i}"]
+    alias_lookup(d, aliases, int, value=i)
+    return alias_lookup(d, aliases, int)
+
+
+def test_alias_lookup_thread_safety():
+    with ThreadPoolExecutor(max_workers=32) as ex:
+        results = list(ex.map(_worker, range(32)))
+    assert results == list(range(32))
+    assert len(_alias_cache) <= _ALIAS_CACHE_MAX


### PR DESCRIPTION
## Summary
- guard alias lookup cache with `threading.Lock` and preserve 16-entry limit
- add unit test exercising concurrent alias lookups

## Testing
- `PYTHONPATH=src pytest tests/test_alias_lookup_threadsafe.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b468ee89088321b11af5dc797618eb