### PR TITLE
Use bounded deque for phase history

### DIFF
--- a/src/tnfr/constants.py
+++ b/src/tnfr/constants.py
@@ -57,6 +57,7 @@ DEFAULTS: Dict[str, Any] = {
     # Coordinación de fase (U’M) global/vecinal por paso
     "PHASE_K_GLOBAL": 0.05,
     "PHASE_K_LOCAL": 0.15,
+    "PHASE_HISTORY_MAXLEN": 50,   # longitud máx. para series de fase
 
     # Coordinación de fase adaptativa (kG/kL dinámicos por estado)
     "PHASE_ADAPT": {

--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -374,9 +374,19 @@ def coordinar_fase_global_vecinal(G, fuerza_global: float | None = None, fuerza_
     g = G.graph
     defaults = DEFAULTS
     hist = g.setdefault("history", {})
-    hist_state = hist.setdefault("phase_state", [])
-    hist_R = hist.setdefault("phase_R", [])
-    hist_disr = hist.setdefault("phase_disr", [])
+    maxlen = int(g.get("PHASE_HISTORY_MAXLEN", defaults.get("PHASE_HISTORY_MAXLEN", 50)))
+    hist_state = hist.setdefault("phase_state", deque(maxlen=maxlen))
+    if not isinstance(hist_state, deque):
+        hist_state = deque(hist_state, maxlen=maxlen)
+        hist["phase_state"] = hist_state
+    hist_R = hist.setdefault("phase_R", deque(maxlen=maxlen))
+    if not isinstance(hist_R, deque):
+        hist_R = deque(hist_R, maxlen=maxlen)
+        hist["phase_R"] = hist_R
+    hist_disr = hist.setdefault("phase_disr", deque(maxlen=maxlen))
+    if not isinstance(hist_disr, deque):
+        hist_disr = deque(hist_disr, maxlen=maxlen)
+        hist["phase_disr"] = hist_disr
     # 0) Si hay fuerzas explícitas, usar y salir del modo adaptativo
     if (fuerza_global is not None) or (fuerza_vecinal is not None):
         kG = float(

--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -22,11 +22,12 @@ def preparar_red(G: nx.Graph, *, override_defaults: bool = False, **overrides) -
         from .constants import merge_overrides
         merge_overrides(G, **overrides)
     # Inicializaciones blandas
+    ph_len = int(G.graph.get("PHASE_HISTORY_MAXLEN", DEFAULTS.get("PHASE_HISTORY_MAXLEN", 50)))
     G.graph.setdefault("history", {
         "C_steps": [],
         "stable_frac": [],
         "phase_sync": [],
-        "kuramoto_R": [], 
+        "kuramoto_R": [],
         "sense_sigma_x": [],
         "sense_sigma_y": [],
         "sense_sigma_mag": [],
@@ -39,10 +40,10 @@ def preparar_red(G: nx.Graph, *, override_defaults: bool = False, **overrides) -
         "Si_lo_frac": [],
         "W_bar": [],
         "phase_kG": [],
-        "phase_kL": [], 
-        "phase_state": [],
-        "phase_R": [], 
-        "phase_disr": [],
+        "phase_kL": [],
+        "phase_state": deque(maxlen=ph_len),
+        "phase_R": deque(maxlen=ph_len),
+        "phase_disr": deque(maxlen=ph_len),
     })
     # REMESH_TAU: alias legado de REMESH_TAU_GLOBAL
     tau = int(


### PR DESCRIPTION
## Summary
- limit phase coordination history using `PHASE_HISTORY_MAXLEN`
- use `deque` for `phase_state`, `phase_R` and `phase_disr` histories with configurable length
- initialize history deques during network preparation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b469f18dac832182f57ff225bc3e94