### PR TITLE
Raise error when applying unknown glyph

### DIFF
--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -270,7 +270,18 @@ def aplicar_glifo_obj(node: NodoProtocol, glifo: str, *, window: Optional[int] =
     glifo = str(glifo)
     op = _NAME_TO_OP.get(glifo)
     if not op:
-        return
+        step_idx = len(node.graph.get("history", {}).get("C_steps", []))
+        node.graph.setdefault("history", {}).setdefault("events", []).append(
+            (
+                "warn",
+                {
+                    "step": step_idx,
+                    "node": getattr(node, "n", None),
+                    "msg": f"glifo desconocido: {glifo}",
+                },
+            )
+        )
+        raise ValueError(f"glifo desconocido: {glifo}")
     if window is None:
         window = int(node.graph.get("GLYPH_HYSTERESIS_WINDOW", DEFAULTS["GLYPH_HYSTERESIS_WINDOW"]))
     node.push_glifo(glifo, window)

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -47,3 +47,13 @@ def test_op_en_sets_epi_kind_on_isolated_node():
     op_EN(node)
     assert node.EPI == 1.0
     assert node.epi_kind == "E’N"
+
+
+def test_aplicar_glifo_invalid_glifo_raises_and_logs():
+    node = NodoTNFR()
+    node.graph["history"] = {}
+    with pytest.raises(ValueError):
+        node.aplicar_glifo("NO_EXISTE")
+    events = node.graph["history"].get("events")
+    assert events and events[-1][0] == "warn"
+    assert "glifo desconocido" in events[-1][1]["msg"]


### PR DESCRIPTION
## Summary
- raise ValueError and log warning when a glyph name is unknown
- add regression test for invalid glyph handling

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b46b20042c83219df1a487656c72ba