### PR TITLE
Ensure export_history creates base directory

### DIFF
--- a/src/tnfr/metrics.py
+++ b/src/tnfr/metrics.py
@@ -4,6 +4,7 @@ from collections import defaultdict, Counter
 import statistics
 import csv
 import json
+import os
 from math import cos
 
 from .constants import (
@@ -237,6 +238,7 @@ def glyph_dwell_stats(G, n) -> Dict[str, Dict[str, float]]:
 def export_history(G, base_path: str, fmt: str = "csv") -> None:
     """Vuelca glifograma y traza σ(t) a archivos CSV o JSON compactos."""
     hist = ensure_history(G)
+    os.makedirs(os.path.dirname(base_path) or ".", exist_ok=True)
     glifo = glifogram_series(G)
     sigma_mag = hist.get("sense_sigma_mag", [])
     sigma = {

--- a/tests/test_export_history.py
+++ b/tests/test_export_history.py
@@ -1,0 +1,24 @@
+import networkx as nx
+
+from tnfr.metrics import export_history
+
+
+def test_export_history_creates_directory_csv(tmp_path):
+    base = tmp_path / "non" / "existing" / "run"
+    dir_path = base.parent
+    assert not dir_path.exists()
+    G = nx.Graph()
+    export_history(G, str(base), fmt="csv")
+    assert dir_path.exists()
+    assert (dir_path / (base.name + "_glifogram.csv")).is_file()
+    assert (dir_path / (base.name + "_sigma.csv")).is_file()
+
+
+def test_export_history_creates_directory_json(tmp_path):
+    base = tmp_path / "other" / "path" / "history"
+    dir_path = base.parent
+    assert not dir_path.exists()
+    G = nx.Graph()
+    export_history(G, str(base), fmt="json")
+    assert dir_path.exists()
+    assert (base.with_suffix(".json")).is_file()


### PR DESCRIPTION
## Summary
- Allow `export_history` to create the output directory before writing history files
- Test directory creation for CSV and JSON export paths

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b46c1b89ac8321b3ce9168f50c4d47