### PR TITLE
Return zero sigma vector for empty graphs

### DIFF
--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -77,6 +77,9 @@ def sigma_vector_global(G, weight_mode: str | None = None) -> Dict[str, float]:
     Interpretación TNFR: |σ| mide cuán alineada está la red en su
     **recorrido glífico**; arg(σ) indica la **dirección funcional** dominante
     (p. ej., torno a I’L/RA para consolidación/distribución, O’Z/Z’HIR para cambio).
+
+    Si ningún nodo posee un glifo registrado, retorna el vector nulo
+    ``{"x": 0.0, "y": 0.0, "mag": 0.0, "angle": 0.0, "n": 0}``.
     """
     cfg = G.graph.get("SIGMA", SIGMA)
     weight_mode = weight_mode or cfg.get("weight", "Si")
@@ -89,7 +92,7 @@ def sigma_vector_global(G, weight_mode: str | None = None) -> Dict[str, float]:
         acc += complex(v["x"], v["y"])
         cnt += 1
     if cnt == 0:
-        return {"x": 1.0, "y": 0.0, "mag": 0.0, "angle": 0.0, "n": 0}
+        return {"x": 0.0, "y": 0.0, "mag": 0.0, "angle": 0.0, "n": 0}
     x, y = acc.real / max(1, cnt), acc.imag / max(1, cnt)
     mag = math.hypot(x, y)
     ang = math.atan2(y, x)

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -15,7 +15,7 @@ try:
     from .sense import sigma_vector_global
 except ImportError:  # pragma: no cover
     def sigma_vector_global(G, *args, **kwargs):
-        return {"x": 1.0, "y": 0.0, "mag": 1.0, "angle": 0.0, "n": 0}
+        return {"x": 0.0, "y": 0.0, "mag": 0.0, "angle": 0.0, "n": 0}
 
 # -------------------------
 # Helpers

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -17,8 +17,7 @@ def test_sigma_vector_global_empty_graph():
     from tnfr.sense import sigma_vector_global
 
     sv = sigma_vector_global(G)
-    assert sv["mag"] == 0.0
-    assert sv["n"] == 0
+    assert sv == {"x": 0.0, "y": 0.0, "mag": 0.0, "angle": 0.0, "n": 0}
 
 
 def test_update_epi_invalid_dt():


### PR DESCRIPTION
## Summary
- Ensure `sigma_vector_global` yields a zero vector when no nodes have glifos
- Document empty graph behaviour and expand edge-case test coverage
- Align trace fallback with new zero-vector semantics

## Testing
- `pip install -e .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b46cebe9088321891544a0c7c9b6d0