### PR TITLE
Validate νf range

### DIFF
--- a/src/tnfr/validators.py
+++ b/src/tnfr/validators.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 from typing import Iterable
 
-from .constants import ALIAS_EPI, DEFAULTS
+from .constants import ALIAS_EPI, ALIAS_VF, DEFAULTS
 from .helpers import _get_attr
 from .sense import sigma_vector_global, GLYPHS_CANONICAL
 from .helpers import last_glifo
@@ -16,6 +16,15 @@ def _validate_epi(G) -> None:
         x = float(_get_attr(G.nodes[n], ALIAS_EPI, 0.0))
         if not (emin - 1e-9 <= x <= emax + 1e-9):
             raise ValueError(f"EPI fuera de rango en nodo {n}: {x}")
+
+
+def _validate_vf(G) -> None:
+    vmin = float(G.graph.get("VF_MIN", DEFAULTS.get("VF_MIN", 0.0)))
+    vmax = float(G.graph.get("VF_MAX", DEFAULTS.get("VF_MAX", 1.0)))
+    for n in G.nodes():
+        x = float(_get_attr(G.nodes[n], ALIAS_VF, 0.0))
+        if not (vmin - 1e-9 <= x <= vmax + 1e-9):
+            raise ValueError(f"VF fuera de rango en nodo {n}: {x}")
 
 
 def _validate_sigma(G) -> None:
@@ -34,5 +43,6 @@ def _validate_glifos(G) -> None:
 def run_validators(G) -> None:
     """Ejecuta todos los validadores de invariantes sobre ``G``."""
     _validate_epi(G)
+    _validate_vf(G)
     _validate_sigma(G)
     _validate_glifos(G)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,6 +1,12 @@
 import pytest
 from tnfr.scenarios import build_graph
-from tnfr.constants import inject_defaults, DEFAULTS, ALIAS_EPI_KIND, ALIAS_EPI
+from tnfr.constants import (
+    inject_defaults,
+    DEFAULTS,
+    ALIAS_EPI_KIND,
+    ALIAS_EPI,
+    ALIAS_VF,
+)
 from tnfr.validators import run_validators
 from tnfr.helpers import _set_attr_str, _set_attr
 
@@ -15,6 +21,14 @@ def test_validator_epi_range():
     G = _base_graph()
     n0 = list(G.nodes())[0]
     _set_attr(G.nodes[n0], ALIAS_EPI, 2.0)
+    with pytest.raises(ValueError):
+        run_validators(G)
+
+
+def test_validator_vf_range():
+    G = _base_graph()
+    n0 = list(G.nodes())[0]
+    _set_attr(G.nodes[n0], ALIAS_VF, 2.0)
     with pytest.raises(ValueError):
         run_validators(G)
 


### PR DESCRIPTION
## Summary
- validate structural frequency νf within `VF_MIN`/`VF_MAX`
- run the new νf validator alongside existing ones
- cover νf bounds in validator tests

## Testing
- `PYTHONPATH=src pytest tests/test_validators.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4724eafd48321a22ddca2d0018421