### PR TITLE
Avoid deque materialization in glyph selector

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -615,7 +615,7 @@ def parametric_glyph_selector(G, n) -> str:
     if certeza < margin:
         hist = nd.get("hist_glifos")
         if hist:
-            prev = list(hist)[-1]
+            prev = hist[-1]
             if isinstance(prev, str) and prev in ("I’L","O’Z","Z’HIR","T’HOL","NA’V","R’A"):
                 return prev
 
@@ -623,7 +623,7 @@ def parametric_glyph_selector(G, n) -> str:
     prev = None
     hist_prev = nd.get("hist_glifos")
     if hist_prev:
-        prev = list(hist_prev)[-1]
+        prev = hist_prev[-1]
     if prev == cand:
         delta_si = _get_attr(nd, ALIAS_dSI, 0.0)
         h = G.graph.get("history", {})


### PR DESCRIPTION
## Summary
- Optimize `parametric_glyph_selector` by indexing `hist_glifos` deques directly instead of converting to lists

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4771546b883219a3c6c5510ac8d78