### PR TITLE
refactor: optimize sigma vector aggregation

### DIFF
--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -86,10 +86,12 @@ def sigma_vector_global(G, weight_mode: str | None = None) -> Dict[str, float]:
     acc = complex(0.0, 0.0)
     cnt = 0
     for n in G.nodes():
-        v = sigma_vector_node(G, n, weight_mode)
-        if v is None:
+        nd = G.nodes[n]
+        g = last_glifo(nd)
+        if not g:
             continue
-        acc += complex(v["x"], v["y"])
+        w = _weight(G, n, weight_mode)
+        acc += glyph_unit(g) * w
         cnt += 1
     if cnt == 0:
         return {"x": 0.0, "y": 0.0, "mag": 0.0, "angle": 0.0, "n": 0}


### PR DESCRIPTION
## Summary
- compute sigma vector directly in `sigma_vector_global`
- avoid per-node helper and accumulate glyph unit vectors and weights

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b477bff9f883219f9da2ed082d7fb6