### PR TITLE
refactor: remove unused typing imports

### DIFF
--- a/src/tnfr/scenarios.py
+++ b/src/tnfr/scenarios.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from typing import Any
 import random
 import networkx as nx
 

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import Dict, Any, List, Tuple
+from typing import Dict, List
 import math
 from collections import Counter
 


### PR DESCRIPTION
## Summary
- delete unused Any import from scenarios
- drop Any and Tuple from sense imports

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b47b6ff3908321921870ffe0f5b29f