### PR TITLE
feat: reuse file parser

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -3,11 +3,6 @@ import argparse
 import json
 from typing import Any, Dict, List, Optional
 
-try:  # pragma: no cover - opcional
-    import yaml  # type: ignore
-except ImportError:  # pragma: no cover - yaml es opcional
-    yaml = None
-
 import networkx as nx
 
 from .constants import inject_defaults, DEFAULTS
@@ -27,6 +22,7 @@ from .gamma import GAMMA_REGISTRY
 from .scenarios import build_graph
 from .presets import get_preset
 from .config import apply_config
+from .helpers import read_structured_file
 
 
 def _save_json(path: str, data: Any) -> None:
@@ -53,14 +49,7 @@ def _args_to_dict(args: argparse.Namespace, prefix: str) -> Dict[str, Any]:
 
 
 def _load_sequence(path: str) -> List[Any]:
-    with open(path, "r", encoding="utf-8") as f:
-        text = f.read()
-    if path.endswith(".yaml") or path.endswith(".yml"):
-        if not yaml:
-            raise RuntimeError("pyyaml no está instalado, usa JSON o instala pyyaml")
-        data = yaml.safe_load(text)
-    else:
-        data = json.loads(text)
+    data = read_structured_file(path)
 
     def parse_token(tok: Any):
         if isinstance(tok, str):

--- a/src/tnfr/config.py
+++ b/src/tnfr/config.py
@@ -6,26 +6,14 @@ reutilizando :func:`tnfr.constants.inject_defaults`.
 
 from __future__ import annotations
 from typing import Any, Dict
-import json
-
-try:  # pragma: no cover - dependencia opcional
-    import yaml  # type: ignore
-except ImportError:  # pragma: no cover
-    yaml = None
+from .helpers import read_structured_file
 
 from .constants import inject_defaults
 
 
 def load_config(path: str) -> Dict[str, Any]:
     """Lee un archivo JSON/YAML y devuelve un ``dict`` con los parámetros."""
-    with open(path, "r", encoding="utf-8") as f:
-        text = f.read()
-    if path.endswith((".yaml", ".yml")):
-        if not yaml:  # pragma: no cover - fallo en entorno sin pyyaml
-            raise RuntimeError("pyyaml no está instalado")
-        data = yaml.safe_load(text)
-    else:
-        data = json.loads(text)
+    data = read_structured_file(path)
     if not isinstance(data, dict):
         raise ValueError("El archivo de configuración debe contener un objeto")
     return data

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -10,6 +10,12 @@ import math
 from collections import deque
 from itertools import islice
 from statistics import fmean, StatisticsError
+import json
+
+try:  # pragma: no cover - dependencia opcional
+    import yaml  # type: ignore
+except ImportError:  # pragma: no cover
+    yaml = None
 
 try:
     import networkx as nx  # solo para tipos
@@ -20,6 +26,20 @@ from .constants import DEFAULTS, ALIAS_VF, ALIAS_THETA, ALIAS_DNFR, ALIAS_EPI, A
 
 if TYPE_CHECKING:  # pragma: no cover - sólo para tipos
     from .node import NodoProtocol
+
+# -------------------------
+# Entrada/salida estructurada
+# -------------------------
+
+def read_structured_file(path: str) -> Any:
+    """Lee un archivo JSON o YAML y devuelve los datos parseados."""
+    with open(path, "r", encoding="utf-8") as f:
+        text = f.read()
+    if path.endswith((".yaml", ".yml")):
+        if not yaml:  # pragma: no cover - dependencia opcional
+            raise RuntimeError("pyyaml no está instalado")
+        return yaml.safe_load(text)
+    return json.loads(text)
 
 # -------------------------
 # Utilidades numéricas

--- a/tests/test_cli_sanity.py
+++ b/tests/test_cli_sanity.py
@@ -1,12 +1,19 @@
 from __future__ import annotations
-import json
 from tnfr.cli import main
+from tnfr.helpers import read_structured_file
 
 
 def test_cli_metrics_runs(tmp_path):
     out = tmp_path / "m.json"
     rc = main(["metrics", "--nodes", "10", "--steps", "50", "--save", str(out)])
     assert rc == 0
-    data = json.loads(out.read_text(encoding="utf-8"))
+    data = read_structured_file(str(out))
     assert "Tg_global" in data
     assert "latency_mean" in data
+
+
+def test_cli_sequence_file(tmp_path):
+    seq_file = tmp_path / "seq.json"
+    seq_file.write_text("[{\"WAIT\": 1}]", encoding="utf-8")
+    rc = main(["sequence", "--sequence-file", str(seq_file), "--nodes", "5"])
+    assert rc == 0

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -8,7 +8,8 @@ from tnfr.constants import (
     ALIAS_VF,
 )
 from tnfr.validators import run_validators
-from tnfr.helpers import _set_attr_str, _set_attr
+from tnfr.helpers import _set_attr_str, _set_attr, read_structured_file
+from tnfr.config import load_config
 
 
 def _base_graph():
@@ -50,3 +51,17 @@ def test_validator_glifo_invalido():
     _set_attr_str(G.nodes[n0], ALIAS_EPI_KIND, "INVALID")
     with pytest.raises(ValueError):
         run_validators(G)
+
+
+def test_read_structured_file_json(tmp_path):
+    path = tmp_path / "cfg.json"
+    path.write_text("{\"x\": 1}", encoding="utf-8")
+    data = read_structured_file(str(path))
+    assert data == {"x": 1}
+
+
+def test_load_config_json(tmp_path):
+    path = tmp_path / "cfg.json"
+    path.write_text("{\"a\": 5}", encoding="utf-8")
+    data = load_config(str(path))
+    assert data["a"] == 5


### PR DESCRIPTION
## Summary
- add read_structured_file utility for JSON/YAML
- use shared parser in load_config and CLI sequence loader
- extend CLI and validator tests to cover new helper

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b47fd47a148321bbbdfe4c66ef12a8