### PR TITLE
refactor: centralize glyph constants as enum

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -17,6 +17,7 @@ from .metrics import (
 )
 from .trace import register_trace
 from .program import play, seq, block, wait, target
+from .types import Glyph
 from .dynamics import step, _update_history, default_glyph_selector, parametric_glyph_selector, validate_canon
 from .gamma import GAMMA_REGISTRY
 from .scenarios import build_graph
@@ -226,7 +227,14 @@ def cmd_sequence(args: argparse.Namespace) -> int:
     elif args.sequence_file:
         program = _load_sequence(args.sequence_file)
     else:
-        program = seq("A’L", "E’N", "I’L", block("O’Z", "Z’HIR", "I’L", repeat=1), "R’A", "SH’A")
+        program = seq(
+            Glyph.AL,
+            Glyph.EN,
+            Glyph.IL,
+            block(Glyph.OZ, Glyph.ZHIR, Glyph.IL, repeat=1),
+            Glyph.RA,
+            Glyph.SHA,
+        )
 
     play(G, program)
 

--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -6,9 +6,10 @@ from .constants import (
     ALIAS_SI, ALIAS_DNFR, ALIAS_EPI,
 )
 from .helpers import _get_attr, clamp01, reciente_glifo
+from .types import Glyph
 
 # Glifos nominales (para evitar typos)
-AL = "A’L"; EN = "E’N"; IL = "I’L"; OZ = "O’Z"; UM = "U’M"; RA = "R’A"; SHA = "SH’A"; VAL = "VA’L"; NUL = "NU’L"; THOL = "T’HOL"; ZHIR = "Z’HIR"; NAV = "NA’V"; REMESH = "RE’MESH"
+AL = Glyph.AL.value; EN = Glyph.EN.value; IL = Glyph.IL.value; OZ = Glyph.OZ.value; UM = Glyph.UM.value; RA = Glyph.RA.value; SHA = Glyph.SHA.value; VAL = Glyph.VAL.value; NUL = Glyph.NUL.value; THOL = Glyph.THOL.value; ZHIR = Glyph.ZHIR.value; NAV = Glyph.NAV.value; REMESH = Glyph.REMESH.value
 
 # -------------------------
 # Estado de gramática por nodo

--- a/src/tnfr/presets.py
+++ b/src/tnfr/presets.py
@@ -1,24 +1,25 @@
 from __future__ import annotations
 from .program import seq, block, wait, ejemplo_canonico_basico
+from .types import Glyph
 
 
 _PRESETS = {
-    "arranque_resonante": seq("A’L", "E’N", "I’L", "R’A", "VA’L", "U’M", wait(3), "SH’A"),
-    "mutacion_contenida": seq("A’L", "E’N", block("O’Z", "Z’HIR", "I’L", repeat=2), "R’A", "SH’A"),
+    "arranque_resonante": seq(Glyph.AL, Glyph.EN, Glyph.IL, Glyph.RA, Glyph.VAL, Glyph.UM, wait(3), Glyph.SHA),
+    "mutacion_contenida": seq(Glyph.AL, Glyph.EN, block(Glyph.OZ, Glyph.ZHIR, Glyph.IL, repeat=2), Glyph.RA, Glyph.SHA),
     "exploracion_acople": seq(
-        "A’L",
-        "E’N",
-        "I’L",
-        "VA’L",
-        "U’M",
-        block("O’Z", "NA’V", "I’L", repeat=1),
-        "R’A",
-        "SH’A",
+        Glyph.AL,
+        Glyph.EN,
+        Glyph.IL,
+        Glyph.VAL,
+        Glyph.UM,
+        block(Glyph.OZ, Glyph.NAV, Glyph.IL, repeat=1),
+        Glyph.RA,
+        Glyph.SHA,
     ),
     "ejemplo_canonico": ejemplo_canonico_basico(),
     # Topologías fractales: expansión/contracción modular
-    "fractal_expand": seq(block("T’HOL", "VA’L", "U’M", repeat=2, close="NU’L"), "R’A"),
-    "fractal_contract": seq(block("T’HOL", "NU’L", "U’M", repeat=2, close="SH’A"), "R’A"),
+    "fractal_expand": seq(block(Glyph.THOL, Glyph.VAL, Glyph.UM, repeat=2, close=Glyph.NUL), Glyph.RA),
+    "fractal_contract": seq(block(Glyph.THOL, Glyph.NUL, Glyph.UM, repeat=2, close=Glyph.SHA), Glyph.RA),
 }
 
 

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -5,24 +5,25 @@ from collections import Counter
 
 from .constants import ALIAS_SI, ALIAS_EPI, SIGMA
 from .helpers import _get_attr, clamp01, register_callback, ensure_history, last_glifo
+from .types import Glyph
 
 # -------------------------
 # Canon: orden circular de glifos y ángulos
 # -------------------------
 GLYPHS_CANONICAL: List[str] = [
-    "A’L",  # 0
-    "E’N",  # 1
-    "I’L",  # 2
-    "U’M",  # 3
-    "R’A",  # 4
-    "VA’L", # 5
-    "O’Z",  # 6
-    "Z’HIR",# 7
-    "NA’V", # 8
-    "T’HOL",# 9
-    "NU’L", #10
-    "SH’A", #11
-    "RE’MESH" #12
+    Glyph.AL.value,   # 0
+    Glyph.EN.value,   # 1
+    Glyph.IL.value,   # 2
+    Glyph.UM.value,   # 3
+    Glyph.RA.value,   # 4
+    Glyph.VAL.value,  # 5
+    Glyph.OZ.value,   # 6
+    Glyph.ZHIR.value, # 7
+    Glyph.NAV.value,  # 8
+    Glyph.THOL.value, # 9
+    Glyph.NUL.value,  #10
+    Glyph.SHA.value,  #11
+    Glyph.REMESH.value #12
 ]
 
 _SIGMA_ANGLES: Dict[str, float] = {g: (2.0*math.pi * i / len(GLYPHS_CANONICAL)) for i, g in enumerate(GLYPHS_CANONICAL)}

--- a/src/tnfr/structural.py
+++ b/src/tnfr/structural.py
@@ -17,6 +17,7 @@ from .dynamics import (
     dnfr_epi_vf_mixed,
 )
 from .operators import aplicar_glifo
+from .types import Glyph
 from .constants import ALIAS_EPI, ALIAS_VF, ALIAS_THETA
 
 
@@ -74,67 +75,67 @@ class Operador:
 # Derivados concretos -------------------------------------------------------
 class Emision(Operador):
     name = "emision"
-    glyph = "A’L"
+    glyph = Glyph.AL.value
 
 
 class Recepcion(Operador):
     name = "recepcion"
-    glyph = "E’N"
+    glyph = Glyph.EN.value
 
 
 class Coherencia(Operador):
     name = "coherencia"
-    glyph = "I’L"
+    glyph = Glyph.IL.value
 
 
 class Disonancia(Operador):
     name = "disonancia"
-    glyph = "O’Z"
+    glyph = Glyph.OZ.value
 
 
 class Acoplamiento(Operador):
     name = "acoplamiento"
-    glyph = "U’M"
+    glyph = Glyph.UM.value
 
 
 class Resonancia(Operador):
     name = "resonancia"
-    glyph = "R’A"
+    glyph = Glyph.RA.value
 
 
 class Silencio(Operador):
     name = "silencio"
-    glyph = "SH’A"
+    glyph = Glyph.SHA.value
 
 
 class Expansion(Operador):
     name = "expansion"
-    glyph = "VA’L"
+    glyph = Glyph.VAL.value
 
 
 class Contraccion(Operador):
     name = "contraccion"
-    glyph = "NU’L"
+    glyph = Glyph.NUL.value
 
 
 class Autoorganizacion(Operador):
     name = "autoorganizacion"
-    glyph = "T’HOL"
+    glyph = Glyph.THOL.value
 
 
 class Mutacion(Operador):
     name = "mutacion"
-    glyph = "Z’HIR"
+    glyph = Glyph.ZHIR.value
 
 
 class Transicion(Operador):
     name = "transicion"
-    glyph = "NA’V"
+    glyph = Glyph.NAV.value
 
 
 class Recursividad(Operador):
     name = "recursividad"
-    glyph = "RE’MESH"
+    glyph = Glyph.REMESH.value
 
 
 OPERADORES = {

--- a/src/tnfr/types.py
+++ b/src/tnfr/types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Dict, Any
 
 
@@ -16,3 +17,22 @@ class NodeState:
         d = {"EPI": self.EPI, "νf": self.vf, "θ": self.theta, "Si": self.Si, "EPI_kind": self.epi_kind}
         d.update(self.extra)
         return d
+
+
+class Glyph(str, Enum):
+    """Glifos canónicos de la TNFR."""
+
+    AL = "A’L"
+    EN = "E’N"
+    IL = "I’L"
+    OZ = "O’Z"
+    UM = "U’M"
+    RA = "R’A"
+    SHA = "SH’A"
+    VAL = "VA’L"
+    NUL = "NU’L"
+    THOL = "T’HOL"
+    ZHIR = "Z’HIR"
+    NAV = "NA’V"
+    REMESH = "RE’MESH"
+

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -2,6 +2,7 @@ import pytest
 import networkx as nx
 from tnfr.node import NodoTNFR
 from tnfr.operators import op_EN
+from tnfr.types import Glyph
 
 from tnfr.dynamics import default_compute_delta_nfr, update_epi_via_nodal_equation
 
@@ -45,7 +46,7 @@ def test_op_en_sets_epi_kind_on_isolated_node():
     node = NodoTNFR(EPI=1.0)
     op_EN(node)
     assert node.EPI == 1.0
-    assert node.epi_kind == "E’N"
+    assert node.epi_kind == Glyph.EN.value
 
 
 def test_aplicar_glifo_invalid_glifo_raises_and_logs():

--- a/tests/test_invariants.py
+++ b/tests/test_invariants.py
@@ -11,6 +11,7 @@ from tnfr.constants import inject_defaults, DEFAULTS
 from tnfr.scenarios import build_graph
 from tnfr.dynamics import step, _update_history
 from tnfr.operators import aplicar_glifo, aplicar_remesh_si_estabilizacion_global
+from tnfr.types import Glyph
 
 
 @pytest.fixture
@@ -48,12 +49,12 @@ def test_conservation_under_IL_SHA(G_small):
 
     for _ in range(5):
         for n in G_small.nodes():
-            aplicar_glifo(G_small, n, "I’L", window=1)
+            aplicar_glifo(G_small, n, Glyph.IL, window=1)
     epi1 = {n: float(G_small.nodes[n].get("EPI", 0.0)) for n in G_small.nodes()}
 
     for _ in range(5):
         for n in G_small.nodes():
-            aplicar_glifo(G_small, n, "SH’A", window=1)
+            aplicar_glifo(G_small, n, Glyph.SHA, window=1)
     epi2 = {n: float(G_small.nodes[n].get("EPI", 0.0)) for n in G_small.nodes()}
 
     for n in G_small.nodes():

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -1,6 +1,7 @@
 import networkx as nx
 
 from tnfr.program import play, seq, block, wait
+from tnfr.types import Glyph
 
 
 def _step_noop(G):
@@ -10,8 +11,8 @@ def _step_noop(G):
 def test_play_records_program_trace_with_block_and_wait():
     G = nx.Graph()
     G.add_node(1)
-    program = seq("A’L", wait(2), block("O’Z"))
+    program = seq(Glyph.AL, wait(2), block(Glyph.OZ))
     play(G, program, step_fn=_step_noop)
     trace = G.graph["history"]["program_trace"]
     assert [e["op"] for e in trace] == ["GLYPH", "WAIT", "GLYPH", "GLYPH"]
-    assert trace[2]["g"] == "T’HOL"
+    assert trace[2]["g"] == Glyph.THOL.value


### PR DESCRIPTION
## Summary
- introduce `Glyph` enum for canonical glyphs
- refactor operators, program DSL, presets, and utilities to use `Glyph`
- update tests to reference enum members

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b48148fcbc832183bbd093eba4423b