### PR TITLE
Use weak refs for per-node jitter cache

### DIFF
--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -1,0 +1,22 @@
+import gc
+import networkx as nx
+
+from tnfr.node import NodoNX
+from tnfr.operators import random_jitter
+
+
+def test_random_jitter_cache_cleared_on_node_removal():
+    G = nx.Graph()
+    G.add_node(0)
+    n0 = NodoNX(G, 0)
+
+    random_jitter(n0, 0.1)
+    cache = G.graph.get("_rnd_cache")
+    assert cache is not None
+    assert len(cache) == 1
+
+    del n0
+    G.remove_node(0)
+    gc.collect()
+
+    assert len(cache) == 0


### PR DESCRIPTION
## Summary
- use a WeakKeyDictionary to cache random generators per node so entries vanish when nodes are deleted
- add regression test ensuring cache entries are released after node removal

## Testing
- `PYTHONPATH=src pytest tests/test_observers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4841e63208321b22589bb3c51f75d