### PR TITLE
Ensure PP metric is zero without RE’MESH events

### DIFF
--- a/src/tnfr/metrics.py
+++ b/src/tnfr/metrics.py
@@ -141,7 +141,11 @@ def _metrics_step(G, *args, **kwargs):
     id_val = counts.get("O’Z", 0) / total
     cm_val = (counts.get("Z’HIR", 0) + counts.get("NA’V", 0)) / total
     ne_val = (counts.get("I’L", 0) + counts.get("T’HOL", 0)) / total
-    pp_val = counts.get("SH’A", 0) / max(1, counts.get("RE’MESH", 0))
+    pp_val = (
+        0.0
+        if counts.get("RE’MESH", 0) == 0
+        else counts.get("SH’A", 0) / counts.get("RE’MESH", 0)
+    )
     hist.setdefault("morph", []).append({"t": t, "ID": id_val, "CM": cm_val, "NE": ne_val, "PP": pp_val})
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,17 @@
+import networkx as nx
+
+from tnfr.constants import attach_defaults
+from tnfr.metrics import _metrics_step
+
+
+def test_pp_val_zero_when_no_remesh():
+    """PP metric should be 0.0 when no RE’MESH events occur."""
+    G = nx.Graph()
+    attach_defaults(G)
+    # Nodo en estado SH’A, pero sin eventos RE’MESH
+    G.add_node(0, EPI_kind="SH’A")
+
+    _metrics_step(G)
+
+    morph = G.graph["history"]["morph"][0]
+    assert morph["PP"] == 0.0


### PR DESCRIPTION
## Summary
- Return 0.0 for PP metric when no RE’MESH events occur
- Add regression test for PP metric without RE’MESH events

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b485578ec48321b377f326302cc868