### PR TITLE
refactor: centralize glyph counting

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from typing import Iterable, Dict, Any, TYPE_CHECKING
 import threading
 import math
-from collections import deque, OrderedDict
+from collections import deque, OrderedDict, Counter
 from itertools import islice
 from statistics import fmean, StatisticsError
 import json
@@ -299,6 +299,32 @@ def last_glifo(nd: Dict[str, Any]) -> str | None:
         return hist[-1]
     except IndexError:
         return None
+
+
+def count_glyphs(G, window: int | None = None) -> Counter:
+    """Cuenta glifos recientes en la red.
+
+    Si ``window`` es ``1`` cuenta solo el último glifo de cada nodo. Con un
+    valor mayor o ``None`` se usa el historial ``hist_glifos`` limitado a los
+    últimos ``window`` elementos por nodo.
+    """
+    counts: Counter[str] = Counter()
+    for _, nd in G.nodes(data=True):
+        if window == 1:
+            g = last_glifo(nd)
+            if g:
+                counts[g] += 1
+            continue
+        hist = nd.get("hist_glifos")
+        if not hist:
+            continue
+        if window is not None and window > 0:
+            start = max(len(hist) - int(window), 0)
+            seq = islice(hist, start, None)
+        else:
+            seq = hist
+        counts.update(seq)
+    return counts
 
 # -------------------------
 # Callbacks Γ(R)

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -4,14 +4,12 @@ observers.py — TNFR canónica
 Observadores y métricas auxiliares.
 """
 from __future__ import annotations
-from collections import Counter
 from typing import Dict, Any
 import math
 import statistics as st
-from itertools import islice
 
 from .constants import ALIAS_DNFR, ALIAS_EPI, ALIAS_THETA, ALIAS_dEPI
-from .helpers import _get_attr, list_mean, register_callback, angle_diff, ensure_history
+from .helpers import _get_attr, list_mean, register_callback, angle_diff, ensure_history, count_glyphs
 
 # -------------------------
 # Observador estándar Γ(R)
@@ -78,19 +76,7 @@ def carga_glifica(G, window: int | None = None) -> dict:
     - window: si se indica, cuenta solo los últimos `window` eventos por nodo; si no, usa el maxlen del deque.
     Retorna un dict con proporciones por glifo y agregados útiles.
     """
-    total = Counter()
-    for n, nd in G.nodes(data=True):
-        hist = nd.get("hist_glifos")
-        if not hist:
-            continue
-        if window is not None and window > 0:
-            start = max(len(hist) - window, 0)
-            seq_iter = islice(hist, start, None)
-        else:
-            seq_iter = hist
-        total.update(seq_iter)
-
-
+    total = count_glyphs(G, window=window)
     count = sum(total.values())
     if count == 0:
         return {"_count": 0}

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -4,7 +4,7 @@ import math
 from collections import Counter
 
 from .constants import ALIAS_SI, ALIAS_EPI, SIGMA
-from .helpers import _get_attr, clamp01, register_callback, ensure_history, last_glifo
+from .helpers import _get_attr, clamp01, register_callback, ensure_history, last_glifo, count_glyphs
 from .types import Glyph
 
 # -------------------------
@@ -131,11 +131,7 @@ def push_sigma_snapshot(G, t: float | None = None) -> None:
     hist.setdefault(key, []).append(sv)
 
     # Conteo de glifos por paso (útil para rosa glífica)
-    counts = Counter()
-    for n in G.nodes():
-        g = last_glifo(G.nodes[n])
-        if g:
-            counts[g] += 1
+    counts = count_glyphs(G, window=1)
     hist.setdefault("sigma_counts", []).append({"t": sv["t"], **counts})
 
     # Trayectoria por nodo (opcional)


### PR DESCRIPTION
## Summary
- add `count_glyphs` helper to compute recent glyph counters
- reuse helper in `push_sigma_snapshot` and `carga_glifica`

## Testing
- `PYTHONPATH=src python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b48637a82c83218ea38fc11a597a1c