### PR TITLE
Add helper to apply glyphs with canonical grammar

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -15,7 +15,7 @@ from .dynamics import step, run, set_delta_nfr_hook, validate_canon
 from .ontosim import preparar_red
 from .observers import attach_standard_observer, coherencia_global, orden_kuramoto
 from .gamma import GAMMA_REGISTRY, eval_gamma, kuramoto_R_psi
-from .grammar import enforce_canonical_grammar, on_applied_glifo
+from .grammar import enforce_canonical_grammar, on_applied_glifo, apply_glyph_with_grammar
 from .sense import (
     GLYPHS_CANONICAL, glyph_angle, glyph_unit,
     sigma_vector_node, sigma_vector_global,
@@ -64,6 +64,7 @@ __all__ = [
     "attach_standard_observer", "coherencia_global", "orden_kuramoto",
     "GAMMA_REGISTRY", "eval_gamma", "kuramoto_R_psi",
     "enforce_canonical_grammar", "on_applied_glifo",
+    "apply_glyph_with_grammar",
     "GLYPHS_CANONICAL", "glyph_angle", "glyph_unit",
     "sigma_vector_node", "sigma_vector_global",
     "push_sigma_snapshot", "sigma_series", "sigma_rose",

--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -6,8 +6,7 @@ from contextlib import contextmanager
 
 from .constants import DEFAULTS
 from .helpers import register_callback
-from .grammar import enforce_canonical_grammar, on_applied_glifo
-from .operators import aplicar_glifo
+from .grammar import apply_glyph_with_grammar
 from .sense import GLYPHS_CANONICAL
 from .types import Glyph
 
@@ -69,12 +68,7 @@ def _all_nodes(G):
 def _apply_glyph_to_targets(G, g: Glyph | str, nodes: Optional[Iterable[Node]] = None):
     nodes = list(nodes) if nodes is not None else _all_nodes(G)
     w = _window(G)
-    g_str = g.value if isinstance(g, Glyph) else str(g)
-    # Pasamos por la gramática antes de aplicar
-    for n in nodes:
-        g_eff = enforce_canonical_grammar(G, n, g_str)
-        aplicar_glifo(G, n, g_eff, window=w)
-        on_applied_glifo(G, n, g_eff)
+    apply_glyph_with_grammar(G, nodes, g, w)
 
 def _advance(G, step_fn: Optional[AdvanceFn] = None):
     if step_fn is None:

--- a/src/tnfr/structural.py
+++ b/src/tnfr/structural.py
@@ -16,7 +16,7 @@ from .dynamics import (
     update_epi_via_nodal_equation,
     dnfr_epi_vf_mixed,
 )
-from .operators import aplicar_glifo
+from .grammar import apply_glyph_with_grammar
 from .types import Glyph
 from .constants import ALIAS_EPI, ALIAS_VF, ALIAS_THETA
 
@@ -69,7 +69,7 @@ class Operador:
     def __call__(self, G: nx.Graph, node, **kw) -> None:
         if self.glyph is None:
             raise NotImplementedError("Operador sin glifo asignado")
-        aplicar_glifo(G, node, self.glyph, **kw)
+        apply_glyph_with_grammar(G, [node], self.glyph, kw.get("window"))
 
 
 # Derivados concretos -------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `apply_glyph_with_grammar` to centralize grammar enforcement
- refactor glyph application to use new helper in program and structural operators
- expand grammar tests for helper equivalence and multi-node behavior

## Testing
- `PYTHONPATH=src pytest tests/test_grammar.py -q`
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b489bf80c883219843cf51beb40ba4