### PR TITLE
chore: remove unused typing import

### DIFF
--- a/src/tnfr/validators.py
+++ b/src/tnfr/validators.py
@@ -1,7 +1,6 @@
 """Validadores de invariantes TNFR."""
 
 from __future__ import annotations
-from typing import Iterable
 
 from .constants import ALIAS_EPI, ALIAS_VF, DEFAULTS
 from .helpers import _get_attr


### PR DESCRIPTION
## Summary
- remove unused typing import from validators module

## Testing
- `ruff check src/tnfr/validators.py`


------
https://chatgpt.com/codex/tasks/task_e_68b48e0e6af88321b4e72afc3788ec60