### PR TITLE
refactor: combine EPI and VF validation

### DIFF
--- a/src/tnfr/validators.py
+++ b/src/tnfr/validators.py
@@ -8,22 +8,18 @@ from .sense import sigma_vector_global, GLYPHS_CANONICAL
 from .helpers import last_glifo
 
 
-def _validate_epi(G) -> None:
+def _validate_epi_vf(G) -> None:
     emin = float(G.graph.get("EPI_MIN", DEFAULTS.get("EPI_MIN", -1.0)))
     emax = float(G.graph.get("EPI_MAX", DEFAULTS.get("EPI_MAX", 1.0)))
-    for n in G.nodes():
-        x = float(_get_attr(G.nodes[n], ALIAS_EPI, 0.0))
-        if not (emin - 1e-9 <= x <= emax + 1e-9):
-            raise ValueError(f"EPI fuera de rango en nodo {n}: {x}")
-
-
-def _validate_vf(G) -> None:
     vmin = float(G.graph.get("VF_MIN", DEFAULTS.get("VF_MIN", 0.0)))
     vmax = float(G.graph.get("VF_MAX", DEFAULTS.get("VF_MAX", 1.0)))
-    for n in G.nodes():
-        x = float(_get_attr(G.nodes[n], ALIAS_VF, 0.0))
-        if not (vmin - 1e-9 <= x <= vmax + 1e-9):
-            raise ValueError(f"VF fuera de rango en nodo {n}: {x}")
+    for n, data in G.nodes(data=True):
+        epi = float(_get_attr(data, ALIAS_EPI, 0.0))
+        if not (emin - 1e-9 <= epi <= emax + 1e-9):
+            raise ValueError(f"EPI fuera de rango en nodo {n}: {epi}")
+        vf = float(_get_attr(data, ALIAS_VF, 0.0))
+        if not (vmin - 1e-9 <= vf <= vmax + 1e-9):
+            raise ValueError(f"VF fuera de rango en nodo {n}: {vf}")
 
 
 def _validate_sigma(G) -> None:
@@ -41,7 +37,6 @@ def _validate_glifos(G) -> None:
 
 def run_validators(G) -> None:
     """Ejecuta todos los validadores de invariantes sobre ``G``."""
-    _validate_epi(G)
-    _validate_vf(G)
+    _validate_epi_vf(G)
     _validate_sigma(G)
     _validate_glifos(G)


### PR DESCRIPTION
## Summary
- validate EPI and VF in one pass over nodes using `G.nodes(data=True)`
- call unified validator from `run_validators`

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b48ea1021083219c0ebfcd2ac5f093