### PR TITLE
refactor: extract phase vector helper

### DIFF
--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -43,9 +43,15 @@ def coherencia_global(G) -> float:
     return 1.0 / (1.0 + dnfr + dEPI)
 
 
-def sincronía_fase(G) -> float:
+def _phase_vectors(G) -> tuple[list, list]:
+    """Devuelve listas de cosenos y senos de las fases nodales."""
     X = [math.cos(_get_attr(G.nodes[n], ALIAS_THETA, 0.0)) for n in G.nodes()]
     Y = [math.sin(_get_attr(G.nodes[n], ALIAS_THETA, 0.0)) for n in G.nodes()]
+    return X, Y
+
+
+def sincronía_fase(G) -> float:
+    X, Y = _phase_vectors(G)
     if not X:
         return 1.0
     th = math.atan2(sum(Y) / len(Y), sum(X) / len(X))
@@ -64,8 +70,7 @@ def sincronía_fase(G) -> float:
 
 def orden_kuramoto(G) -> float:
     """R en [0,1], 1 = fases perfectamente alineadas."""
-    X = [math.cos(_get_attr(G.nodes[n], ALIAS_THETA, 0.0)) for n in G.nodes()]
-    Y = [math.sin(_get_attr(G.nodes[n], ALIAS_THETA, 0.0)) for n in G.nodes()]
+    X, Y = _phase_vectors(G)
     if not X:
         return 1.0
     R = ((sum(X)**2 + sum(Y)**2) ** 0.5) / max(1, len(X))

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -1,8 +1,13 @@
 import gc
+import math
+import statistics as st
 import networkx as nx
 
 from tnfr.node import NodoNX
 from tnfr.operators import random_jitter
+from tnfr.constants import ALIAS_THETA
+from tnfr.observers import sincronía_fase, orden_kuramoto
+from tnfr.helpers import angle_diff, _set_attr
 
 
 def test_random_jitter_cache_cleared_on_node_removal():
@@ -20,3 +25,21 @@ def test_random_jitter_cache_cleared_on_node_removal():
     gc.collect()
 
     assert len(cache) == 0
+
+
+def test_phase_observers_match_manual_calculation():
+    G = nx.Graph()
+    angles = [0.0, math.pi / 2, math.pi]
+    for idx, th in enumerate(angles):
+        G.add_node(idx)
+        _set_attr(G.nodes[idx], ALIAS_THETA, th)
+
+    X = [math.cos(th) for th in angles]
+    Y = [math.sin(th) for th in angles]
+    th_mean = math.atan2(sum(Y) / len(Y), sum(X) / len(X))
+    var = st.pvariance([angle_diff(th, th_mean) for th in angles])
+    expected_sync = 1.0 / (1.0 + var)
+    assert math.isclose(sincronía_fase(G), expected_sync)
+
+    R = ((sum(X) ** 2 + sum(Y) ** 2) ** 0.5) / len(angles)
+    assert math.isclose(orden_kuramoto(G), float(R))


### PR DESCRIPTION
## Summary
- add `_phase_vectors` helper to compute cosine and sine phase components
- reuse helper in `sincronía_fase` and `orden_kuramoto`
- test observers against manual calculations

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b49023d9d88321bc1d6a73f2243cc2