### PR TITLE
Refactor structured file reading to use Path and stream parsing

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 import argparse
 import json
 from typing import Any, Dict, List, Optional
+from pathlib import Path
 
 import networkx as nx
 
@@ -49,7 +50,7 @@ def _args_to_dict(args: argparse.Namespace, prefix: str) -> Dict[str, Any]:
     return out
 
 
-def _load_sequence(path: str) -> List[Any]:
+def _load_sequence(path: Path) -> List[Any]:
     data = read_structured_file(path)
 
     def parse_token(tok: Any):
@@ -96,7 +97,7 @@ def _build_graph_from_args(args: argparse.Namespace) -> nx.Graph:
     """Construye y configura un grafo a partir de los argumentos del CLI."""
     G = build_graph(n=args.nodes, topology=args.topology, seed=args.seed)
     if args.config:
-        apply_config(G, args.config)
+        apply_config(G, Path(args.config))
     _attach_callbacks(G)
     validate_canon(G)
     if args.dt is not None:
@@ -237,7 +238,7 @@ def cmd_sequence(args: argparse.Namespace) -> int:
     if args.preset:
         program = get_preset(args.preset)
     elif args.sequence_file:
-        program = _load_sequence(args.sequence_file)
+        program = _load_sequence(Path(args.sequence_file))
     else:
         program = seq(
             Glyph.AL,

--- a/src/tnfr/config.py
+++ b/src/tnfr/config.py
@@ -6,12 +6,13 @@ reutilizando :func:`tnfr.constants.inject_defaults`.
 
 from __future__ import annotations
 from typing import Any, Dict
+from pathlib import Path
 from .helpers import read_structured_file
 
 from .constants import inject_defaults
 
 
-def load_config(path: str) -> Dict[str, Any]:
+def load_config(path: Path) -> Dict[str, Any]:
     """Lee un archivo JSON/YAML y devuelve un ``dict`` con los parámetros."""
     data = read_structured_file(path)
     if not isinstance(data, dict):
@@ -19,7 +20,7 @@ def load_config(path: str) -> Dict[str, Any]:
     return data
 
 
-def apply_config(G, path: str) -> None:
+def apply_config(G, path: Path) -> None:
     """Inyecta parámetros desde ``path`` sobre ``G.graph``.
 
     Se reutiliza :func:`inject_defaults` para mantener la semántica de los

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -11,6 +11,7 @@ from itertools import islice
 from statistics import fmean, StatisticsError
 import json
 from functools import lru_cache
+from pathlib import Path
 
 try:  # pragma: no cover - dependencia opcional
     import yaml  # type: ignore
@@ -31,15 +32,15 @@ if TYPE_CHECKING:  # pragma: no cover - sólo para tipos
 # Entrada/salida estructurada
 # -------------------------
 
-def read_structured_file(path: str) -> Any:
+
+def read_structured_file(path: Path) -> Any:
     """Lee un archivo JSON o YAML y devuelve los datos parseados."""
-    with open(path, "r", encoding="utf-8") as f:
-        text = f.read()
-    if path.endswith((".yaml", ".yml")):
-        if not yaml:  # pragma: no cover - dependencia opcional
-            raise RuntimeError("pyyaml no está instalado")
-        return yaml.safe_load(text)
-    return json.loads(text)
+    with path.open("r", encoding="utf-8") as f:
+        if path.suffix in {".yaml", ".yml"}:
+            if not yaml:  # pragma: no cover - dependencia opcional
+                raise RuntimeError("pyyaml no está instalado")
+            return yaml.safe_load(f)
+        return json.load(f)
 
 # -------------------------
 # Utilidades numéricas

--- a/tests/test_cli_sanity.py
+++ b/tests/test_cli_sanity.py
@@ -7,7 +7,7 @@ def test_cli_metrics_runs(tmp_path):
     out = tmp_path / "m.json"
     rc = main(["metrics", "--nodes", "10", "--steps", "50", "--save", str(out)])
     assert rc == 0
-    data = read_structured_file(str(out))
+    data = read_structured_file(out)
     assert "Tg_global" in data
     assert "latency_mean" in data
 

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -37,5 +37,5 @@ def test_load_sequence_json_yaml(tmp_path):
     ypath.write_text(yaml.safe_dump(data))
 
     expected = seq("AL", block("OZ", "EN", "RA"), wait(1))
-    assert _load_sequence(str(jpath)) == expected
-    assert _load_sequence(str(ypath)) == expected
+    assert _load_sequence(jpath) == expected
+    assert _load_sequence(ypath) == expected

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -56,12 +56,12 @@ def test_validator_glifo_invalido():
 def test_read_structured_file_json(tmp_path):
     path = tmp_path / "cfg.json"
     path.write_text("{\"x\": 1}", encoding="utf-8")
-    data = read_structured_file(str(path))
+    data = read_structured_file(path)
     assert data == {"x": 1}
 
 
 def test_load_config_json(tmp_path):
     path = tmp_path / "cfg.json"
     path.write_text("{\"a\": 5}", encoding="utf-8")
-    data = load_config(str(path))
+    data = load_config(path)
     assert data["a"] == 5


### PR DESCRIPTION
## Summary
- Refactor `read_structured_file` to accept `Path` and parse JSON/YAML from file objects without loading entire files
- Update config and CLI helpers to work with `Path` inputs
- Adjust tests for new `Path`-based API

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b49171804083218a59d31201500a69