### PR TITLE
Remove register_callback import from program module

### DIFF
--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from contextlib import contextmanager
 
 from .constants import DEFAULTS
-from .helpers import register_callback
 from .grammar import apply_glyph_with_grammar
 from .sense import GLYPHS_CANONICAL
 from .types import Glyph


### PR DESCRIPTION
## Summary
- remove obsolete register_callback import in program API

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b493b5a0148321b9c5ac5be17fb869