### PR TITLE
Cache RE’MESH count in PP metric calculation

### DIFF
--- a/src/tnfr/metrics.py
+++ b/src/tnfr/metrics.py
@@ -130,11 +130,8 @@ def _update_morph_metrics(G, hist, counts, t):
     id_val = counts.get("O’Z", 0) / total
     cm_val = (counts.get("Z’HIR", 0) + counts.get("NA’V", 0)) / total
     ne_val = (counts.get("I’L", 0) + counts.get("T’HOL", 0)) / total
-    pp_val = (
-        0.0
-        if counts.get("RE’MESH", 0) == 0
-        else counts.get("SH’A", 0) / counts.get("RE’MESH", 0)
-    )
+    remesh = counts.get("RE’MESH", 0)
+    pp_val = 0.0 if remesh == 0 else counts["SH’A"] / remesh
     hist.setdefault("morph", []).append({"t": t, "ID": id_val, "CM": cm_val, "NE": ne_val, "PP": pp_val})
 
 


### PR DESCRIPTION
## Summary
- cache RE’MESH count locally when computing PP morph metric
- keep behavior unchanged when no RE’MESH events occur

## Testing
- `pytest tests/test_metrics.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4958986748321ae33981558b3fd0e