### PR TITLE
Validate file extension before reading structured file

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -35,8 +35,11 @@ if TYPE_CHECKING:  # pragma: no cover - sólo para tipos
 
 def read_structured_file(path: Path) -> Any:
     """Lee un archivo JSON o YAML y devuelve los datos parseados."""
+    suffix = path.suffix.lower()
+    if suffix not in {".json", ".yaml", ".yml"}:
+        raise ValueError(f"Extensión de archivo no soportada: {path.suffix}")
     with path.open("r", encoding="utf-8") as f:
-        if path.suffix in {".yaml", ".yml"}:
+        if suffix in {".yaml", ".yml"}:
             if not yaml:  # pragma: no cover - dependencia opcional
                 raise RuntimeError("pyyaml no está instalado")
             return yaml.safe_load(f)

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -60,6 +60,13 @@ def test_read_structured_file_json(tmp_path):
     assert data == {"x": 1}
 
 
+def test_read_structured_file_invalid_extension(tmp_path):
+    path = tmp_path / "cfg.txt"
+    path.write_text("{}", encoding="utf-8")
+    with pytest.raises(ValueError):
+        read_structured_file(path)
+
+
 def test_load_config_json(tmp_path):
     path = tmp_path / "cfg.json"
     path.write_text("{\"a\": 5}", encoding="utf-8")


### PR DESCRIPTION
## Summary
- Ensure `read_structured_file` only accepts `.json`, `.yaml`, or `.yml` and raise a clear `ValueError` for unsupported extensions.
- Add unit test covering the new invalid-extension behavior.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b49870daf08321aa1f72dadb7ad039