### PR TITLE
Handle None default in alias_lookup

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -145,6 +145,8 @@ def alias_lookup(
         return d[key]
 
     if default is not _sentinel:
+        if default is None:
+            return None
         return conv(default)
     return None
 

--- a/tests/test_alias_lookup_default.py
+++ b/tests/test_alias_lookup_default.py
@@ -1,0 +1,9 @@
+from tnfr.helpers import alias_lookup
+
+
+def test_alias_lookup_default_none_returns_none():
+    d = {}
+    result = alias_lookup(d, ["x"], int, default=None)
+    assert result is None
+    assert d == {}
+


### PR DESCRIPTION
## Summary
- Avoid converting `None` defaults in `alias_lookup`
- Test `alias_lookup` for `default=None`

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4992c6cd08321888a66ae1e5cab46