### PR TITLE
Refactor CSV export helper and extend export history tests

### DIFF
--- a/tests/test_export_history.py
+++ b/tests/test_export_history.py
@@ -1,4 +1,5 @@
 import networkx as nx
+import json
 
 from tnfr.metrics import export_history
 
@@ -22,3 +23,27 @@ def test_export_history_creates_directory_json(tmp_path):
     export_history(G, str(base), fmt="json")
     assert dir_path.exists()
     assert (base.with_suffix(".json")).is_file()
+
+
+def test_export_history_writes_optional_files(tmp_path):
+    base = tmp_path / "extras" / "run"
+    G = nx.Graph()
+    hist = G.graph.setdefault("history", {})
+    hist["morph"] = [{"t": 0, "ID": 1, "CM": 2, "NE": 3, "PP": 4}]
+    hist["EPI_support"] = [{"t": 0, "size": 1, "epi_norm": 0.5}]
+    export_history(G, str(base), fmt="csv")
+    dir_path = base.parent
+    assert (dir_path / (base.name + "_morph.csv")).is_file()
+    assert (dir_path / (base.name + "_epi_support.csv")).is_file()
+
+
+def test_export_history_json_contains_optional(tmp_path):
+    base = tmp_path / "extras" / "jsonrun"
+    G = nx.Graph()
+    hist = G.graph.setdefault("history", {})
+    hist["morph"] = [{"t": 0, "ID": 1, "CM": 2, "NE": 3, "PP": 4}]
+    hist["EPI_support"] = [{"t": 0, "size": 1, "epi_norm": 0.5}]
+    export_history(G, str(base), fmt="json")
+    data = json.loads((base.with_suffix(".json")).read_text())
+    assert data["morph"]
+    assert data["epi_support"]


### PR DESCRIPTION
## Summary
- add `_write_csv` helper to centralize CSV writing
- simplify `export_history` by reusing `_write_csv` for glifogram, sigma, morph and epi_support
- add tests ensuring optional CSV and JSON files are generated

## Testing
- `PYTHONPATH=src pytest tests/test_export_history.py -q`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b49e03567c8321b9b291fff4d05ed4