### PR TITLE
Optimize Tg update by passing save_by_node once

### DIFF
--- a/src/tnfr/metrics.py
+++ b/src/tnfr/metrics.py
@@ -51,13 +51,15 @@ def _tg_state(nd: Dict[str, Any]) -> Dict[str, Any]:
 # -------------
 
 
-def _update_tg(G, hist, dt):
-    """Acumula tiempos glíficos por nodo y devuelve conteos y latencia."""
+def _update_tg(G, hist, dt, save_by_node: bool):
+    """Acumula tiempos glíficos por nodo y devuelve conteos y latencia.
+
+    ``save_by_node`` controla si se registran las corridas por nodo.
+    """
     counts = Counter()
     n_total = 0
     n_latent = 0
 
-    save_by_node = bool(G.graph.get("METRICS", METRICS).get("save_by_node", True))
     tg_total = hist.setdefault("Tg_total", defaultdict(float))
     tg_by_node = hist.setdefault("Tg_by_node", {})
 
@@ -153,7 +155,8 @@ def _metrics_step(G, *args, **kwargs):
     dt = float(G.graph.get("DT", 1.0))
     t = float(G.graph.get("_t", 0.0))
 
-    counts, n_total, n_latent = _update_tg(G, hist, dt)
+    save_by_node = bool(G.graph.get("METRICS", METRICS).get("save_by_node", True))
+    counts, n_total, n_latent = _update_tg(G, hist, dt, save_by_node)
     _update_glifogram(G, hist, counts, t)
     _update_latency_index(G, hist, n_total, n_latent, t)
     _update_epi_support(G, hist, t)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -15,3 +15,35 @@ def test_pp_val_zero_when_no_remesh():
 
     morph = G.graph["history"]["morph"][0]
     assert morph["PP"] == 0.0
+
+
+def test_save_by_node_flag_keeps_metrics_equal():
+    """Disabling per-node storage should not alter global metrics."""
+    G_true = nx.Graph()
+    attach_defaults(G_true)
+    G_true.graph["METRICS"] = dict(G_true.graph["METRICS"])
+    G_true.graph["METRICS"]["save_by_node"] = True
+
+    G_false = nx.Graph()
+    attach_defaults(G_false)
+    G_false.graph["METRICS"] = dict(G_false.graph["METRICS"])
+    G_false.graph["METRICS"]["save_by_node"] = False
+
+    for G in (G_true, G_false):
+        G.add_node(0, EPI_kind="OZ")
+        G.add_node(1, EPI_kind="SHA")
+        G.graph["_t"] = 0
+        _metrics_step(G)
+        G.nodes[0]["EPI_kind"] = "NAV"
+        G.graph["_t"] = 1
+        _metrics_step(G)
+
+    hist_true = G_true.graph["history"]
+    hist_false = G_false.graph["history"]
+
+    assert hist_true["Tg_total"] == hist_false["Tg_total"]
+    assert hist_true["glifogram"] == hist_false["glifogram"]
+    assert hist_true["latency_index"] == hist_false["latency_index"]
+    assert hist_true["morph"] == hist_false["morph"]
+    assert hist_true["Tg_by_node"] != {}
+    assert hist_false.get("Tg_by_node", {}) == {}


### PR DESCRIPTION
## Summary
- allow `_update_tg` to receive a `save_by_node` flag
- compute the `save_by_node` option once in `_metrics_step`
- verify global metrics unchanged when per-node storage is disabled

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b49ede66188321864c9bb5cfffaa14