### PR TITLE
refactor: centralize glyph constants

### DIFF
--- a/src/tnfr/constants_glifos.py
+++ b/src/tnfr/constants_glifos.py
@@ -1,0 +1,53 @@
+"""
+constants_glifos.py — categorización y ángulos de glifos.
+
+Centraliza constantes relacionadas con las familias de glifos y el plano
+angular utilizado por los observadores de sentido.
+"""
+from __future__ import annotations
+
+import math
+from typing import Dict, List
+
+from .types import Glyph
+
+# -------------------------
+# Clasificaciones funcionales de glifos
+# -------------------------
+
+ESTABILIZADORES: List[str] = [
+    Glyph.IL.value,
+    Glyph.RA.value,
+    Glyph.UM.value,
+    Glyph.SHA.value,
+]
+
+DISRUPTIVOS: List[str] = [
+    Glyph.OZ.value,
+    Glyph.ZHIR.value,
+    Glyph.NAV.value,
+    Glyph.THOL.value,
+]
+
+# -------------------------
+# Mapa de ángulos glíficos
+# -------------------------
+
+# Ángulos canónicos para todos los glifos reconocidos. Las categorías
+# anteriores se distribuyen uniformemente en el círculo y se ajustan a
+# orientaciones semánticas específicas en el plano σ.
+ANGLE_MAP: Dict[str, float] = {
+    Glyph.AL.value: 0.0,
+    Glyph.EN.value: 2 * math.pi / 13,
+    Glyph.IL.value: 0.0,
+    Glyph.UM.value: math.pi / 2,
+    Glyph.RA.value: math.pi / 4,
+    Glyph.VAL.value: 10 * math.pi / 13,
+    Glyph.OZ.value: math.pi,
+    Glyph.ZHIR.value: 5 * math.pi / 4,
+    Glyph.NAV.value: 3 * math.pi / 2,
+    Glyph.THOL.value: 7 * math.pi / 4,
+    Glyph.NUL.value: 20 * math.pi / 13,
+    Glyph.SHA.value: 3 * math.pi / 4,
+    Glyph.REMESH.value: 24 * math.pi / 13,
+}

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -11,10 +11,7 @@ import statistics as st
 from .constants import ALIAS_DNFR, ALIAS_EPI, ALIAS_THETA, ALIAS_dEPI
 from .helpers import _get_attr, list_mean, register_callback, angle_diff, ensure_history, count_glyphs
 from .sense import glyph_unit, SIGMA_ANGLE_KEYS
-
-# Clasificaciones funcionales de glifos
-ESTABILIZADORES = ["IL", "RA", "UM", "SHA"]
-DISRUPTIVOS = ["OZ", "ZHIR", "NAV", "THOL"]
+from .constants_glifos import ESTABILIZADORES, DISRUPTIVOS
 
 # -------------------------
 # Observador estándar Γ(R)

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -4,8 +4,16 @@ import math
 from collections import Counter
 
 from .constants import ALIAS_SI, ALIAS_EPI, SIGMA
-from .helpers import _get_attr, clamp01, register_callback, ensure_history, last_glifo, count_glyphs
+from .helpers import (
+    _get_attr,
+    clamp01,
+    register_callback,
+    ensure_history,
+    last_glifo,
+    count_glyphs,
+)
 from .types import Glyph
+from .constants_glifos import ANGLE_MAP, ESTABILIZADORES, DISRUPTIVOS
 
 # -------------------------
 # Canon: orden circular de glifos y ángulos
@@ -26,34 +34,11 @@ GLYPHS_CANONICAL: List[str] = [
     Glyph.REMESH.value #12
 ]
 
-_SIGMA_ANGLES: Dict[str, float] = {g: (2.0*math.pi * i / len(GLYPHS_CANONICAL)) for i, g in enumerate(GLYPHS_CANONICAL)}
-
 # Glifos relevantes para el plano Σ de observadores de sentido
-SIGMA_ANGLE_KEYS: tuple[str, ...] = (
-    Glyph.IL.value,
-    Glyph.RA.value,
-    Glyph.UM.value,
-    Glyph.SHA.value,
-    Glyph.OZ.value,
-    Glyph.ZHIR.value,
-    Glyph.NAV.value,
-    Glyph.THOL.value,
-)
-
-# Ajustes específicos de ángulos para Σ
-_SIGMA_ANGLES.update({
-    Glyph.IL.value: 0.0,
-    Glyph.RA.value: math.pi/4,
-    Glyph.UM.value: math.pi/2,
-    Glyph.SHA.value: 3*math.pi/4,
-    Glyph.OZ.value: math.pi,
-    Glyph.ZHIR.value: 5*math.pi/4,
-    Glyph.NAV.value: 3*math.pi/2,
-    Glyph.THOL.value: 7*math.pi/4,
-})
+SIGMA_ANGLE_KEYS: tuple[str, ...] = tuple(ESTABILIZADORES + DISRUPTIVOS)
 
 GLYPH_UNITS: Dict[str, complex] = {
-    g: complex(math.cos(a), math.sin(a)) for g, a in _SIGMA_ANGLES.items()
+    g: complex(math.cos(a), math.sin(a)) for g, a in ANGLE_MAP.items()
 }
 
 # -------------------------
@@ -61,7 +46,7 @@ GLYPH_UNITS: Dict[str, complex] = {
 # -------------------------
 
 def glyph_angle(g: str) -> float:
-    return float(_SIGMA_ANGLES.get(g, 0.0))
+    return float(ANGLE_MAP.get(g, 0.0))
 
 
 def glyph_unit(g: str) -> complex:

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -8,6 +8,7 @@ from tnfr.node import NodoNX
 from tnfr.operators import random_jitter
 from tnfr.constants import ALIAS_THETA
 from tnfr.observers import sincronía_fase, orden_kuramoto, carga_glifica, sigma_vector
+from tnfr.constants_glifos import ANGLE_MAP, ESTABILIZADORES, DISRUPTIVOS
 from tnfr.helpers import angle_diff, _set_attr
 
 
@@ -71,18 +72,10 @@ def test_sigma_vector_consistency(monkeypatch):
 
     res = sigma_vector(G)
 
-    # Cálculo esperado con ángulos previos
-    angles = {
-        "IL": 0.0,
-        "RA": math.pi / 4,
-        "UM": math.pi / 2,
-        "SHA": 3 * math.pi / 4,
-        "OZ": math.pi,
-        "ZHIR": 5 * math.pi / 4,
-        "NAV": 3 * math.pi / 2,
-        "THOL": 7 * math.pi / 4,
-    }
-    total = sum(dist.get(k, 0.0) for k in angles.keys())
+    # Cálculo esperado con el mapa de ángulos canónico
+    keys = ESTABILIZADORES + DISRUPTIVOS
+    angles = {k: ANGLE_MAP[k] for k in keys}
+    total = sum(dist.get(k, 0.0) for k in keys)
     x = sum(dist.get(k, 0.0) / total * math.cos(a) for k, a in angles.items())
     y = sum(dist.get(k, 0.0) / total * math.sin(a) for k, a in angles.items())
     mag = math.hypot(x, y)


### PR DESCRIPTION
## Summary
- extract glyph category lists and angle map into new `constants_glifos` module
- use shared constants in `observers` and `sense` to remove inline duplicates
- adjust observers test to rely on centralized glyph constants

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4a085346c832195177cafc6388279