### PR TITLE
refactor: centralize EPI scaling

### DIFF
--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -183,16 +183,22 @@ def _op_SHA(node: NodoProtocol) -> None:  # SHA — Silencio
     node.vf = factor * node.vf
 
 
+def _scale_epi(node: NodoProtocol, factor: float, glyph: Glyph) -> None:
+    """Escala ``EPI`` del nodo y actualiza ``epi_kind``."""
+    node.EPI = factor * node.EPI
+    node.epi_kind = glyph.value if isinstance(glyph, Glyph) else str(glyph)
+
+
 def _op_VAL(node: NodoProtocol) -> None:  # VAL — Expansión
     gf = get_glyph_factors(node)
     s = float(gf.get("VAL_scale", 1.15))
-    node.EPI = s * node.EPI
+    _scale_epi(node, s, Glyph.VAL)
 
 
 def _op_NUL(node: NodoProtocol) -> None:  # NUL — Contracción
     gf = get_glyph_factors(node)
     s = float(gf.get("NUL_scale", 0.85))
-    node.EPI = s * node.EPI
+    _scale_epi(node, s, Glyph.NUL)
 
 
 def _op_THOL(node: NodoProtocol) -> None:  # THOL — Autoorganización


### PR DESCRIPTION
## Summary
- add helper to scale a node's EPI and update its glyph
- apply helper in VAL and NUL operators

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4a54c18d883218c4e67c2dc1efc68