### PR TITLE
refactor: simplify alias lookup

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -10,7 +10,6 @@ from collections import deque, Counter
 from itertools import islice
 from statistics import fmean, StatisticsError
 import json
-from functools import lru_cache
 from pathlib import Path
 
 try:  # pragma: no cover - dependencia opcional
@@ -97,15 +96,6 @@ def phase_distance(a: float, b: float) -> float:
 _sentinel = object()
 
 
-@lru_cache(maxsize=16)
-def _resolve_alias(alist: tuple[str, ...], keys: frozenset[str]) -> str | None:
-    """Devuelve la primera alias presente en ``keys`` o ``None``."""
-    for k in alist:
-        if k in keys:
-            return k
-    return None
-
-
 def alias_lookup(
     d: Dict[str, Any],
     aliases: Iterable[str],
@@ -122,14 +112,8 @@ def alias_lookup(
     falla.
     """
     alist = tuple(aliases)
-    # Resolver utilizando la caché LRU
-    k = _resolve_alias(alist, frozenset(d.keys()))
-    candidates = []
-    if k is not None:
-        candidates.append(k)
-    candidates.extend(a for a in alist if a != k)
 
-    for key in candidates:
+    for key in alist:
         if key in d:
             if value is not _sentinel:
                 d[key] = conv(value)

--- a/tests/test_alias_lookup_threadsafe.py
+++ b/tests/test_alias_lookup_threadsafe.py
@@ -1,6 +1,6 @@
 from concurrent.futures import ThreadPoolExecutor
 
-from tnfr.helpers import alias_lookup, _resolve_alias
+from tnfr.helpers import alias_lookup
 
 
 def _worker(i):
@@ -14,4 +14,3 @@ def test_alias_lookup_thread_safety():
     with ThreadPoolExecutor(max_workers=32) as ex:
         results = list(ex.map(_worker, range(32)))
     assert results == list(range(32))
-    assert _resolve_alias.cache_info().currsize <= 16


### PR DESCRIPTION
## Summary
- simplify `alias_lookup` by iterating over aliases directly
- drop `_resolve_alias` cache and related tests

## Testing
- `PYTHONPATH=src pytest tests/test_alias_lookup_default.py tests/test_alias_lookup_threadsafe.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4a77dfdb483219d28d1bddb2873a8