### PR TITLE
test: add graph fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+import networkx as nx
+
+from tnfr.constants import attach_defaults
+
+
+@pytest.fixture
+def graph_canon():
+    """Return a new graph with default attributes attached."""
+
+    def _factory():
+        G = nx.Graph()
+        attach_defaults(G)
+        return G
+
+    return _factory
+

--- a/tests/test_edge_cases.py
+++ b/tests/test_edge_cases.py
@@ -1,5 +1,4 @@
 import pytest
-import networkx as nx
 from tnfr.node import NodoTNFR
 from tnfr.operators import op_EN
 from tnfr.types import Glyph
@@ -7,22 +6,22 @@ from tnfr.types import Glyph
 from tnfr.dynamics import default_compute_delta_nfr, update_epi_via_nodal_equation
 
 
-def test_empty_graph_handling():
-    G = nx.Graph()
+def test_empty_graph_handling(graph_canon):
+    G = graph_canon()
     default_compute_delta_nfr(G)
     update_epi_via_nodal_equation(G)  # should not raise
 
 
-def test_sigma_vector_global_empty_graph():
-    G = nx.Graph()
+def test_sigma_vector_global_empty_graph(graph_canon):
+    G = graph_canon()
     from tnfr.sense import sigma_vector_global
 
     sv = sigma_vector_global(G)
     assert sv == {"x": 0.0, "y": 0.0, "mag": 0.0, "angle": 0.0, "n": 0}
 
 
-def test_update_epi_invalid_dt():
-    G = nx.Graph()
+def test_update_epi_invalid_dt(graph_canon):
+    G = graph_canon()
     G.add_node(1)
     with pytest.raises(ValueError):
         update_epi_via_nodal_equation(G, dt=-0.1)
@@ -30,8 +29,8 @@ def test_update_epi_invalid_dt():
         update_epi_via_nodal_equation(G, dt="bad")
 
 
-def test_dnfr_weights_normalization():
-    G = nx.Graph()
+def test_dnfr_weights_normalization(graph_canon):
+    G = graph_canon()
     G.graph["DNFR_WEIGHTS"] = {"phase": -1, "epi": -1, "vf": -1}
     default_compute_delta_nfr(G)
     weights = G.graph["_DNFR_META"]["weights_norm"]

--- a/tests/test_export_history.py
+++ b/tests/test_export_history.py
@@ -1,33 +1,32 @@
-import networkx as nx
 import json
 
 from tnfr.metrics import export_history
 
 
-def test_export_history_creates_directory_csv(tmp_path):
+def test_export_history_creates_directory_csv(tmp_path, graph_canon):
     base = tmp_path / "non" / "existing" / "run"
     dir_path = base.parent
     assert not dir_path.exists()
-    G = nx.Graph()
+    G = graph_canon()
     export_history(G, str(base), fmt="csv")
     assert dir_path.exists()
     assert (dir_path / (base.name + "_glifogram.csv")).is_file()
     assert (dir_path / (base.name + "_sigma.csv")).is_file()
 
 
-def test_export_history_creates_directory_json(tmp_path):
+def test_export_history_creates_directory_json(tmp_path, graph_canon):
     base = tmp_path / "other" / "path" / "history"
     dir_path = base.parent
     assert not dir_path.exists()
-    G = nx.Graph()
+    G = graph_canon()
     export_history(G, str(base), fmt="json")
     assert dir_path.exists()
     assert (base.with_suffix(".json")).is_file()
 
 
-def test_export_history_writes_optional_files(tmp_path):
+def test_export_history_writes_optional_files(tmp_path, graph_canon):
     base = tmp_path / "extras" / "run"
-    G = nx.Graph()
+    G = graph_canon()
     hist = G.graph.setdefault("history", {})
     hist["morph"] = [{"t": 0, "ID": 1, "CM": 2, "NE": 3, "PP": 4}]
     hist["EPI_support"] = [{"t": 0, "size": 1, "epi_norm": 0.5}]
@@ -37,9 +36,9 @@ def test_export_history_writes_optional_files(tmp_path):
     assert (dir_path / (base.name + "_epi_support.csv")).is_file()
 
 
-def test_export_history_json_contains_optional(tmp_path):
+def test_export_history_json_contains_optional(tmp_path, graph_canon):
     base = tmp_path / "extras" / "jsonrun"
-    G = nx.Graph()
+    G = graph_canon()
     hist = G.graph.setdefault("history", {})
     hist["morph"] = [{"t": 0, "ID": 1, "CM": 2, "NE": 3, "PP": 4}]
     hist["EPI_support"] = [{"t": 0, "size": 1, "epi_norm": 0.5}]

--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -1,12 +1,11 @@
-import networkx as nx
 import pytest
 
 from tnfr.constants import attach_defaults, merge_overrides
 from tnfr.dynamics import update_epi_via_nodal_equation
 
 
-def test_gamma_linear_integration():
-    G = nx.Graph()
+def test_gamma_linear_integration(graph_canon):
+    G = graph_canon()
     G.add_nodes_from([0, 1])
     attach_defaults(G)
     merge_overrides(G, GAMMA={"type": "kuramoto_linear", "beta": 1.0, "R0": 0.0})

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -1,4 +1,3 @@
-import networkx as nx
 from collections import deque
 
 from tnfr.constants import attach_defaults
@@ -10,28 +9,19 @@ from tnfr.grammar import (
 )
 
 
-def make_graph():
-    import networkx as nx
-
-    G = nx.Graph()
+def test_compatibility_fallback(graph_canon):
+    G = graph_canon()
     G.add_node(0)
     attach_defaults(G)
-    return G
-
-
-def test_compatibility_fallback():
-    G = make_graph()
-    from collections import deque
-
     nd = G.nodes[0]
     nd['hist_glifos'] = deque([AL])
     assert enforce_canonical_grammar(G, 0, IL) == EN
 
 
-def test_precondition_oz_to_zhir():
-    G = make_graph()
-    from collections import deque
-
+def test_precondition_oz_to_zhir(graph_canon):
+    G = graph_canon()
+    G.add_node(0)
+    attach_defaults(G)
     nd = G.nodes[0]
     nd['hist_glifos'] = deque([NAV])
     nd['ΔNFR'] = 0.0
@@ -40,10 +30,10 @@ def test_precondition_oz_to_zhir():
     assert enforce_canonical_grammar(G, 0, ZHIR) == ZHIR
 
 
-def test_thol_closure():
-    G = make_graph()
-    from collections import deque
-
+def test_thol_closure(graph_canon):
+    G = graph_canon()
+    G.add_node(0)
+    attach_defaults(G)
     nd = G.nodes[0]
     nd['hist_glifos'] = deque([THOL])
     on_applied_glifo(G, 0, THOL)
@@ -57,8 +47,10 @@ def test_thol_closure():
     assert enforce_canonical_grammar(G, 0, EN) == SHA
 
 
-def test_lag_counters_enforced():
-    G = make_graph()
+def test_lag_counters_enforced(graph_canon):
+    G = graph_canon()
+    G.add_node(0)
+    attach_defaults(G)
     G.graph['AL_MAX_LAG'] = 2
     G.graph['EN_MAX_LAG'] = 2
     from tnfr.dynamics import step
@@ -70,9 +62,13 @@ def test_lag_counters_enforced():
         assert all(v <= 2 for v in hist['since_EN'].values())
 
 
-def test_apply_glyph_with_grammar_equivalence():
-    G_manual = make_graph()
-    G_func = make_graph()
+def test_apply_glyph_with_grammar_equivalence(graph_canon):
+    G_manual = graph_canon()
+    G_manual.add_node(0)
+    attach_defaults(G_manual)
+    G_func = graph_canon()
+    G_func.add_node(0)
+    attach_defaults(G_func)
 
     # Aplicación manual
     g_eff = enforce_canonical_grammar(G_manual, 0, ZHIR)
@@ -86,12 +82,11 @@ def test_apply_glyph_with_grammar_equivalence():
     assert G_manual.nodes[0] == G_func.nodes[0]
 
 
-def test_apply_glyph_with_grammar_multiple_nodes():
-    G = nx.Graph()
+def test_apply_glyph_with_grammar_multiple_nodes(graph_canon):
+    G = graph_canon()
     G.add_node(0, theta=0.0)
     G.add_node(1)
     attach_defaults(G)
-    from collections import deque
     G.nodes[0]['hist_glifos'] = deque([OZ])
 
     apply_glyph_with_grammar(G, [0, 1], ZHIR, 1)

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,11 +1,10 @@
-import networkx as nx
 import pytest
 
 from tnfr.dynamics import _update_history
 
 
-def test_phase_sync_and_kuramoto_recorded():
-    G = nx.Graph()
+def test_phase_sync_and_kuramoto_recorded(graph_canon):
+    G = graph_canon()
     G.add_node(1, theta=0.0)
     G.add_node(2, theta=0.0)
     _update_history(G)

--- a/tests/test_history_series.py
+++ b/tests/test_history_series.py
@@ -1,12 +1,10 @@
-import networkx as nx
-
 from tnfr.constants import attach_defaults
 from tnfr.dynamics import step
 from tnfr.gamma import GAMMA_REGISTRY
 
 
-def test_history_delta_si_and_B():
-    G = nx.Graph()
+def test_history_delta_si_and_B(graph_canon):
+    G = graph_canon()
     G.add_node(0, EPI=0.0, νf=0.5, θ=0.0)
     attach_defaults(G)
     step(G, apply_glyphs=False)
@@ -16,8 +14,8 @@ def test_history_delta_si_and_B():
     assert "B" in hist and len(hist["B"]) >= 2
 
 
-def test_gamma_kuramoto_tanh_registry():
-    G = nx.Graph()
+def test_gamma_kuramoto_tanh_registry(graph_canon):
+    G = graph_canon()
     G.add_nodes_from([0, 1])
     attach_defaults(G)
     G.nodes[0]["θ"] = 0.0

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,15 +1,13 @@
-import networkx as nx
-
 from tnfr.constants import attach_defaults
 from tnfr.metrics import _metrics_step
 
 
-def test_pp_val_zero_when_no_remesh():
+def test_pp_val_zero_when_no_remesh(graph_canon):
     """PP metric should be 0.0 when no REMESH events occur."""
-    G = nx.Graph()
-    attach_defaults(G)
+    G = graph_canon()
     # Nodo en estado SHA, pero sin eventos REMESH
     G.add_node(0, EPI_kind="SHA")
+    attach_defaults(G)
 
     _metrics_step(G)
 
@@ -17,21 +15,20 @@ def test_pp_val_zero_when_no_remesh():
     assert morph["PP"] == 0.0
 
 
-def test_save_by_node_flag_keeps_metrics_equal():
+def test_save_by_node_flag_keeps_metrics_equal(graph_canon):
     """Disabling per-node storage should not alter global metrics."""
-    G_true = nx.Graph()
-    attach_defaults(G_true)
+    G_true = graph_canon()
     G_true.graph["METRICS"] = dict(G_true.graph["METRICS"])
     G_true.graph["METRICS"]["save_by_node"] = True
 
-    G_false = nx.Graph()
-    attach_defaults(G_false)
+    G_false = graph_canon()
     G_false.graph["METRICS"] = dict(G_false.graph["METRICS"])
     G_false.graph["METRICS"]["save_by_node"] = False
 
     for G in (G_true, G_false):
         G.add_node(0, EPI_kind="OZ")
         G.add_node(1, EPI_kind="SHA")
+        attach_defaults(G)
         G.graph["_t"] = 0
         _metrics_step(G)
         G.nodes[0]["EPI_kind"] = "NAV"

--- a/tests/test_nav.py
+++ b/tests/test_nav.py
@@ -1,12 +1,11 @@
-import networkx as nx
 import pytest
 
 from tnfr.constants import attach_defaults
 from tnfr.operators import op_NAV
 
 
-def test_nav_converges_to_vf_without_jitter():
-    G = nx.Graph()
+def test_nav_converges_to_vf_without_jitter(graph_canon):
+    G = graph_canon()
     G.add_node(0)
     attach_defaults(G)
     nd = G.nodes[0]
@@ -19,8 +18,8 @@ def test_nav_converges_to_vf_without_jitter():
     assert nd["ΔNFR"] == pytest.approx(expected)
 
 
-def test_nav_strict_sets_dnfr_to_vf():
-    G = nx.Graph()
+def test_nav_strict_sets_dnfr_to_vf(graph_canon):
+    G = graph_canon()
     G.add_node(0)
     attach_defaults(G)
     nd = G.nodes[0]

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -1,7 +1,6 @@
 import gc
 import math
 import statistics as st
-import networkx as nx
 import pytest
 
 from tnfr.node import NodoNX
@@ -12,8 +11,8 @@ from tnfr.constants_glifos import ANGLE_MAP, ESTABILIZADORES, DISRUPTIVOS
 from tnfr.helpers import angle_diff, _set_attr
 
 
-def test_random_jitter_cache_cleared_on_node_removal():
-    G = nx.Graph()
+def test_random_jitter_cache_cleared_on_node_removal(graph_canon):
+    G = graph_canon()
     G.add_node(0)
     n0 = NodoNX(G, 0)
 
@@ -29,8 +28,8 @@ def test_random_jitter_cache_cleared_on_node_removal():
     assert len(cache) == 0
 
 
-def test_phase_observers_match_manual_calculation():
-    G = nx.Graph()
+def test_phase_observers_match_manual_calculation(graph_canon):
+    G = graph_canon()
     angles = [0.0, math.pi / 2, math.pi]
     for idx, th in enumerate(angles):
         G.add_node(idx)
@@ -47,8 +46,8 @@ def test_phase_observers_match_manual_calculation():
     assert math.isclose(orden_kuramoto(G), float(R))
 
 
-def test_carga_glifica_uses_module_constants(monkeypatch):
-    G = nx.Graph()
+def test_carga_glifica_uses_module_constants(monkeypatch, graph_canon):
+    G = graph_canon()
     G.add_node(0, hist_glifos=["A"])
     G.add_node(1, hist_glifos=["B"])
 
@@ -62,10 +61,10 @@ def test_carga_glifica_uses_module_constants(monkeypatch):
     assert dist["_disruptivos"] == pytest.approx(0.5)
 
 
-def test_sigma_vector_consistency(monkeypatch):
+def test_sigma_vector_consistency(monkeypatch, graph_canon):
     import tnfr.observers as obs
 
-    G = nx.Graph()
+    G = graph_canon()
     # Distribución ficticia de glifos
     dist = {"IL": 0.4, "RA": 0.3, "ZHIR": 0.1, "AL": 0.2, "_count": 10}
     monkeypatch.setattr(obs, "carga_glifica", lambda G, window=None: dist)

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -1,5 +1,4 @@
 import json
-import networkx as nx
 import pytest
 
 from tnfr.cli import _load_sequence
@@ -13,8 +12,8 @@ def _step_noop(G):
     G.graph["_t"] = G.graph.get("_t", 0.0) + 1.0
 
 
-def test_play_records_program_trace_with_block_and_wait():
-    G = nx.Graph()
+def test_play_records_program_trace_with_block_and_wait(graph_canon):
+    G = graph_canon()
     G.add_node(1)
     program = seq(Glyph.AL, wait(2), block(Glyph.OZ))
     play(G, program, step_fn=_step_noop)

--- a/tests/test_remesh.py
+++ b/tests/test_remesh.py
@@ -1,13 +1,11 @@
-import networkx as nx
 from collections import deque
-import networkx as nx
 
 from tnfr.constants import attach_defaults
 from tnfr.operators import aplicar_remesh_si_estabilizacion_global
 
 
-def test_aplicar_remesh_usa_parametro_personalizado():
-    G = nx.Graph()
+def test_aplicar_remesh_usa_parametro_personalizado(graph_canon):
+    G = graph_canon()
     G.add_node(0)
     attach_defaults(G)
     G.graph["REMESH_REQUIRE_STABILITY"] = False
@@ -30,8 +28,8 @@ def test_aplicar_remesh_usa_parametro_personalizado():
     assert G.graph["_last_remesh_step"] == len(hist["stable_frac"])
 
 
-def test_remesh_alpha_hard_ignores_glyph_factor():
-    G = nx.Graph()
+def test_remesh_alpha_hard_ignores_glyph_factor(graph_canon):
+    G = graph_canon()
     G.add_node(0)
     attach_defaults(G)
     G.graph["REMESH_REQUIRE_STABILITY"] = False

--- a/tests/test_remesh_community.py
+++ b/tests/test_remesh_community.py
@@ -3,8 +3,8 @@ from tnfr.constants import attach_defaults
 from tnfr.operators import aplicar_remesh_red_topologico
 
 
-def test_remesh_community_reduces_nodes_and_preserves_connectivity():
-    G = nx.Graph()
+def test_remesh_community_reduces_nodes_and_preserves_connectivity(graph_canon):
+    G = graph_canon()
     G.add_edges_from([(0,1),(1,2),(2,0),(3,4),(4,5),(5,3),(2,3)])
     attach_defaults(G)
     for n in G.nodes():

--- a/tests/test_selector_norms.py
+++ b/tests/test_selector_norms.py
@@ -1,10 +1,8 @@
-import networkx as nx
-
 from tnfr.dynamics import step, default_glyph_selector, parametric_glyph_selector
 
 
-def _make_graph():
-    G = nx.Graph()
+def _make_graph(graph_canon):
+    G = graph_canon()
     G.add_nodes_from([0, 1])
     G.add_edge(0, 1)
     G.graph["GRAMMAR_CANON"] = {"enabled": False}
@@ -12,15 +10,15 @@ def _make_graph():
     return G
 
 
-def test_default_selector_does_not_compute_norms():
-    G = _make_graph()
+def test_default_selector_does_not_compute_norms(graph_canon):
+    G = _make_graph(graph_canon)
     G.graph["glyph_selector"] = default_glyph_selector
     step(G, use_Si=False, apply_glyphs=True)
     assert "_sel_norms" not in G.graph
 
 
-def test_parametric_selector_computes_norms():
-    G = _make_graph()
+def test_parametric_selector_computes_norms(graph_canon):
+    G = _make_graph(graph_canon)
     G.graph["glyph_selector"] = parametric_glyph_selector
     step(G, use_Si=False, apply_glyphs=True)
     assert "_sel_norms" in G.graph

--- a/tests/test_vf_coherencia.py
+++ b/tests/test_vf_coherencia.py
@@ -1,12 +1,11 @@
-import networkx as nx
 import pytest
 
 from tnfr.constants import attach_defaults
 from tnfr.dynamics import step
 
 
-def test_vf_converge_to_neighbor_average_when_stable():
-    G = nx.Graph()
+def test_vf_converge_to_neighbor_average_when_stable(graph_canon):
+    G = graph_canon()
     G.add_edge(0, 1)
     attach_defaults(G)
     # configuraciones para estabilidad


### PR DESCRIPTION
## Summary
- add `graph_canon` fixture to build graphs with defaults
- refactor tests to use `graph_canon` instead of manual `nx.Graph` setup

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4a85f437c8321aa437aef258422d3