### PR TITLE
refactor: clarify REMESH_TAU alias handling

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -29,6 +29,7 @@ from .constants import (
     ALIAS_VF, ALIAS_THETA, ALIAS_DNFR, ALIAS_EPI, ALIAS_SI,
     ALIAS_dEPI, ALIAS_D2EPI, ALIAS_dVF, ALIAS_D2VF, ALIAS_dSI,
     ALIAS_EPI_KIND,
+    get_param,
 )
 from .gamma import eval_gamma
 from .helpers import (
@@ -756,19 +757,9 @@ def step(G, *, dt: float | None = None, use_Si: bool = True, apply_glyphs: bool 
     # 7) Observadores ligeros
     _update_history(G)
     # dynamics.py — dentro de step(), justo antes del punto 8)
-    # REMESH_TAU: alias legado de REMESH_TAU_GLOBAL
-    tau_g = int(
-        G.graph.get(
-            "REMESH_TAU_GLOBAL",
-            G.graph.get("REMESH_TAU", DEFAULTS["REMESH_TAU_GLOBAL"]),
-        )
-    )
-    tau_l = int(
-        G.graph.get(
-            "REMESH_TAU_LOCAL",
-            G.graph.get("REMESH_TAU", DEFAULTS["REMESH_TAU_LOCAL"]),
-        )
-    )
+    # REMESH_TAU: alias legado resuelto por ``get_param``
+    tau_g = int(get_param(G, "REMESH_TAU_GLOBAL"))
+    tau_l = int(get_param(G, "REMESH_TAU_LOCAL"))
     tau = max(tau_g, tau_l)
     maxlen = max(2 * tau + 5, 64)
     epi_hist = G.graph.get("_epi_hist")

--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import networkx as nx
 from collections import deque
 
-from .constants import DEFAULTS, attach_defaults
+from .constants import DEFAULTS, attach_defaults, get_param
 from .dynamics import step as _step, run as _run
 from .dynamics import default_compute_delta_nfr
 from .initialization import init_node_attrs
@@ -44,13 +44,8 @@ def preparar_red(G: nx.Graph, *, override_defaults: bool = False, **overrides) -
         "phase_R": deque(maxlen=ph_len),
         "phase_disr": deque(maxlen=ph_len),
     })
-    # REMESH_TAU: alias legado de REMESH_TAU_GLOBAL
-    tau = int(
-        G.graph.get(
-            "REMESH_TAU_GLOBAL",
-            G.graph.get("REMESH_TAU", DEFAULTS["REMESH_TAU_GLOBAL"]),
-        )
-    )
+    # REMESH_TAU: alias legado resuelto por ``get_param``
+    tau = int(get_param(G, "REMESH_TAU_GLOBAL"))
     maxlen = max(2 * tau + 5, 64)
     G.graph.setdefault("_epi_hist", deque(maxlen=maxlen))
     # Auto-attach del observador estándar si se pide

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -8,7 +8,7 @@ import weakref
 import networkx as nx
 from networkx.algorithms import community as nx_comm
 
-from .constants import DEFAULTS, ALIAS_EPI
+from .constants import DEFAULTS, ALIAS_EPI, get_param
 from .helpers import (
     clamp,
     clamp01,
@@ -335,19 +335,9 @@ def _remesh_alpha_info(G):
 
 def aplicar_remesh_red(G) -> None:
     """REMESH a escala de red usando _epi_hist con memoria multi-escala."""
-    # REMESH_TAU: alias legado de REMESH_TAU_GLOBAL
-    tau_g = int(
-        G.graph.get(
-            "REMESH_TAU_GLOBAL",
-            G.graph.get("REMESH_TAU", DEFAULTS["REMESH_TAU_GLOBAL"]),
-        )
-    )
-    tau_l = int(
-        G.graph.get(
-            "REMESH_TAU_LOCAL",
-            G.graph.get("REMESH_TAU", DEFAULTS["REMESH_TAU_LOCAL"]),
-        )
-    )
+    # REMESH_TAU: alias legado resuelto por ``get_param``
+    tau_g = int(get_param(G, "REMESH_TAU_GLOBAL"))
+    tau_l = int(get_param(G, "REMESH_TAU_LOCAL"))
     tau_req = max(tau_g, tau_l)
     alpha, alpha_src = _remesh_alpha_info(G)
     G.graph["_REMESH_ALPHA_SRC"] = alpha_src


### PR DESCRIPTION
## Summary
- document REMESH_TAU as a legacy alias and track aliases separately
- add `get_param` helper to resolve aliases with deprecation warnings
- update internal uses to rely on `REMESH_TAU_GLOBAL`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4aafdded48321bb1b96dff14fed9c