### PR TITLE
Handle parse errors for structured files

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -41,8 +41,14 @@ def read_structured_file(path: Path) -> Any:
         if suffix in {".yaml", ".yml"}:
             if not yaml:  # pragma: no cover - dependencia opcional
                 raise RuntimeError("pyyaml no está instalado")
-            return yaml.safe_load(f)
-        return json.load(f)
+            try:
+                return yaml.safe_load(f)
+            except yaml.YAMLError as e:
+                raise ValueError(f"Error al parsear YAML en {path}: {e}") from e
+        try:
+            return json.load(f)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Error al parsear JSON en {path}: {e}") from e
 
 # -------------------------
 # Utilidades numéricas

--- a/tests/test_read_structured_file_errors.py
+++ b/tests/test_read_structured_file_errors.py
@@ -1,0 +1,20 @@
+import pytest
+from pathlib import Path
+from tnfr.helpers import read_structured_file
+
+
+def test_read_structured_file_corrupt_json(tmp_path: Path):
+    path = tmp_path / "bad.json"
+    path.write_text("{bad json}", encoding="utf-8")
+    with pytest.raises(ValueError) as excinfo:
+        read_structured_file(path)
+    assert str(path) in str(excinfo.value)
+
+
+def test_read_structured_file_corrupt_yaml(tmp_path: Path):
+    yaml = pytest.importorskip("yaml")
+    path = tmp_path / "bad.yaml"
+    path.write_text("a: [1, 2", encoding="utf-8")
+    with pytest.raises(ValueError) as excinfo:
+        read_structured_file(path)
+    assert str(path) in str(excinfo.value)


### PR DESCRIPTION
## Summary
- Add error handling for JSON/YAML parsing in `read_structured_file` with detailed file paths
- Test corrupted JSON/YAML inputs to ensure informative exceptions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4ac88d41c8321bb869a3d04606b35