### PR TITLE
Use single RNG for node attribute initialization

### DIFF
--- a/src/tnfr/initialization.py
+++ b/src/tnfr/initialization.py
@@ -45,33 +45,35 @@ def init_node_attrs(G: nx.Graph, *, override: bool = True) -> nx.Graph:
     si_max = float(G.graph.get("INIT_SI_MAX", 0.7))
     epi_val = float(G.graph.get("INIT_EPI_VALUE", 0.0))
 
+    rand = random.Random(seed)
+
     for idx, n in enumerate(G.nodes()):
         nd = G.nodes[n]
 
         if override or "EPI" not in nd:
             nd["EPI"] = epi_val
 
+        rand.seed(seed + idx)
+
         if init_rand_phase:
-            th_rng = random.Random(seed + 1009 * idx)
             if override or "θ" not in nd:
-                nd["θ"] = th_rng.uniform(th_min, th_max)
+                nd["θ"] = rand.uniform(th_min, th_max)
         else:
             if override:
                 nd["θ"] = 0.0
             else:
                 nd.setdefault("θ", 0.0)
 
-        vf_rng = random.Random(seed * 1000003 + idx)
         if vf_mode == "uniform":
-            vf = vf_rng.uniform(float(vf_uniform_min), float(vf_uniform_max))
+            vf = rand.uniform(float(vf_uniform_min), float(vf_uniform_max))
         elif vf_mode == "normal":
             for _ in range(16):
-                cand = vf_rng.normalvariate(vf_mean, vf_std)
+                cand = rand.normalvariate(vf_mean, vf_std)
                 if vf_min_lim <= cand <= vf_max_lim:
                     vf = cand
                     break
             else:
-                vf = min(max(vf_rng.normalvariate(vf_mean, vf_std), vf_min_lim), vf_max_lim)
+                vf = min(max(rand.normalvariate(vf_mean, vf_std), vf_min_lim), vf_max_lim)
         else:
             vf = float(nd.get("νf", 0.5))
         if clamp_to_limits:
@@ -79,8 +81,7 @@ def init_node_attrs(G: nx.Graph, *, override: bool = True) -> nx.Graph:
         if override or "νf" not in nd:
             nd["νf"] = float(vf)
 
-        si_rng = random.Random(seed * 2000003 + idx)
-        si = si_rng.uniform(si_min, si_max)
+        si = rand.uniform(si_min, si_max)
         if override or "Si" not in nd:
             nd["Si"] = float(si)
 


### PR DESCRIPTION
## Summary
- Replace multiple random generators with a single seeded RNG in `init_node_attrs`
- Derive per-node seeds for θ, νf, and Si to keep results reproducible

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4ae8ecfc48321a6e15eceaaf98b20