### PR TITLE
Use math.pi for theta defaults

### DIFF
--- a/src/tnfr/constants.py
+++ b/src/tnfr/constants.py
@@ -7,6 +7,7 @@ Provee utilidades para inyectarlos en G.graph.
 from __future__ import annotations
 from typing import Dict, Any
 from types import MappingProxyType
+import math
 import warnings
 
 # -------------------------
@@ -33,8 +34,8 @@ DEFAULTS: Dict[str, Any] = {
 
     # --- Inicialización (evitar simetrías) ---
     "INIT_RANDOM_PHASE": True,        # si True, θ ~ U[-π, π]
-    "INIT_THETA_MIN": -3.141592653589793,
-    "INIT_THETA_MAX":  3.141592653589793,
+    "INIT_THETA_MIN": -math.pi,
+    "INIT_THETA_MAX":  math.pi,
 
     "INIT_VF_MODE": "uniform",        # "uniform" | "normal"
     # para uniform:


### PR DESCRIPTION
## Summary
- replace hardcoded π constants with `math.pi` in `DEFAULTS`
- add `import math` for the constants module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4af53ada08321bd61d6ec249d4839