### PR TITLE
Handle tuple aliases in alias_lookup

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -117,7 +117,9 @@ def alias_lookup(
     devolviendo ``default`` convertido si ninguna alias coincide o la conversión
     falla.
     """
-    alist = tuple(aliases)
+    if not isinstance(aliases, tuple):
+        aliases = tuple(aliases)
+    alist = aliases
 
     for key in alist:
         if key in d:


### PR DESCRIPTION
## Summary
- Ensure `alias_lookup` accepts tuple aliases without reconversion

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4aff5c00883219b971bb7cfdef890