### PR TITLE
Avoid unnecessary jitter randomization when amplitude is zero

### DIFF
--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -64,6 +64,8 @@ def _node_offset(G, n) -> int:
 
 def random_jitter(node: NodoProtocol, amplitude: float) -> float:
     """Return deterministic noise in ``[-amplitude, amplitude]`` for ``node``."""
+    if amplitude == 0:
+        return 0.0
 
     base_seed = int(node.graph.get("RANDOM_SEED", 0))
     cache = node.graph.setdefault("_rnd_cache", weakref.WeakKeyDictionary())


### PR DESCRIPTION
## Summary
- Skip seed and RNG creation in `random_jitter` when amplitude is zero

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4b07c4e8083219e74f6339c411afe