### PR TITLE
Raise error for invalid glyphs

### DIFF
--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -100,8 +100,7 @@ def _flatten(seq: Sequence[Token]) -> List[Tuple[str, Any]]:
             # item debería ser un glifo
             g = item.value if isinstance(item, Glyph) else str(item)
             if g not in GLYPHS_CANONICAL:
-                # Permitimos glifos no listados (compat futuros), pero no forzamos
-                pass
+                raise ValueError(f"Glifo no canónico: {g}")
             ops.append(("GLYPH", g))
     return ops
 


### PR DESCRIPTION
## Summary
- Raise `ValueError` when `_flatten` encounters a non-canonical glyph name

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4b2b1a7408321be59b76442e91a0c