### PR TITLE
Prevent duplicate trace callback registration

### DIFF
--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -140,5 +140,10 @@ def register_trace(G) -> None:
       - sigma: vector global del plano del sentido
       - glifos: conteos por glifo tras el paso
     """
+    if G.graph.get("_trace_registered"):
+        return
+
     register_callback(G, when="before_step", func=_trace_before, name="trace_before")
     register_callback(G, when="after_step", func=_trace_after, name="trace_after")
+
+    G.graph["_trace_registered"] = True

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,0 +1,15 @@
+from tnfr.trace import register_trace
+
+
+def test_register_trace_idempotent(graph_canon):
+    G = graph_canon()
+    register_trace(G)
+    # callbacks should be registered once and flag set
+    assert G.graph["_trace_registered"] is True
+    before = list(G.graph["callbacks"]["before_step"])
+    after = list(G.graph["callbacks"]["after_step"])
+
+    register_trace(G)
+
+    assert list(G.graph["callbacks"]["before_step"]) == before
+    assert list(G.graph["callbacks"]["after_step"]) == after


### PR DESCRIPTION
## Summary
- guard `register_trace` against repeated registration
- add unit test confirming callbacks are registered only once

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4b36929b88321b24e8a3dba482d1c