### PR TITLE
Use get_param for glyph window retrieval

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -708,7 +708,7 @@ def step(G, *, dt: float | None = None, use_Si: bool = True, apply_glyphs: bool 
     # 3) Selección glífica + aplicación (con lags obligatorios AL/EN)
     if apply_glyphs:
         from .operators import aplicar_glifo
-        window = int(G.graph.get("GLYPH_HYSTERESIS_WINDOW", DEFAULTS["GLYPH_HYSTERESIS_WINDOW"]))
+        window = int(get_param(G, "GLYPH_HYSTERESIS_WINDOW"))
         use_canon = bool(G.graph.get("GRAMMAR_CANON", DEFAULTS.get("GRAMMAR_CANON", {})).get("enabled", False))
 
         al_max = int(G.graph.get("AL_MAX_LAG", DEFAULTS["AL_MAX_LAG"]))

--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -4,6 +4,7 @@ from typing import Dict, Any, Set, Iterable, Optional
 from .constants import (
     DEFAULTS,
     ALIAS_SI, ALIAS_DNFR, ALIAS_EPI,
+    get_param,
 )
 from .helpers import _get_attr, clamp01, reciente_glifo
 from .types import Glyph
@@ -142,7 +143,7 @@ def apply_glyph_with_grammar(G, nodes: Optional[Iterable[Any]], glyph: Glyph | s
     from .operators import aplicar_glifo
 
     if window is None:
-        window = int(G.graph.get("GLYPH_HYSTERESIS_WINDOW", DEFAULTS.get("GLYPH_HYSTERESIS_WINDOW", 1)))
+        window = int(get_param(G, "GLYPH_HYSTERESIS_WINDOW"))
 
     g_str = glyph.value if isinstance(glyph, Glyph) else str(glyph)
     for n in list(G.nodes() if nodes is None else nodes):

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -310,7 +310,7 @@ def aplicar_glifo_obj(node: NodoProtocol, glifo: Glyph | str, *, window: Optiona
 
     op = _NAME_TO_OP.get(g)
     if window is None:
-        window = int(node.graph.get("GLYPH_HYSTERESIS_WINDOW", DEFAULTS["GLYPH_HYSTERESIS_WINDOW"]))
+        window = int(get_param(node, "GLYPH_HYSTERESIS_WINDOW"))
     node.push_glifo(g.value, window)
     op(node)
 

--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -4,7 +4,7 @@ from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Uni
 from dataclasses import dataclass
 from contextlib import contextmanager
 
-from .constants import DEFAULTS
+from .constants import get_param
 from .grammar import apply_glyph_with_grammar
 from .sense import GLYPHS_CANONICAL
 from .types import Glyph
@@ -55,7 +55,7 @@ def _forced_selector(G, glyph: Glyph):
             G.graph["glyph_selector"] = prev
 
 def _window(G) -> int:
-    return int(G.graph.get("GLYPH_HYSTERESIS_WINDOW", DEFAULTS.get("GLYPH_HYSTERESIS_WINDOW", 1)))
+    return int(get_param(G, "GLYPH_HYSTERESIS_WINDOW"))
 
 def _all_nodes(G):
     return list(G.nodes())


### PR DESCRIPTION
## Summary
- Fetch GLYPH_HYSTERESIS_WINDOW via `get_param` in program, grammar, operators, and dynamics to avoid direct `G.graph` access

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4b40eef808321a2c1ffe883163fad