### PR TITLE
feat(node): guard edge weight updates

### DIFF
--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -89,7 +89,9 @@ class NodoProtocol(Protocol):
     def has_edge(self, other: "NodoProtocol") -> bool:
         ...
 
-    def add_edge(self, other: "NodoProtocol", weight: float) -> None:
+    def add_edge(
+        self, other: "NodoProtocol", weight: float, *, overwrite: bool = False
+    ) -> None:
         ...
 
     def offset(self) -> int:
@@ -129,7 +131,18 @@ class NodoTNFR:
         """Devuelve el peso de la arista hacia ``other`` o ``0.0`` si no existe."""
         return self._neighbors.get(other, 0.0)
 
-    def add_edge(self, other: "NodoTNFR", weight: float = 1.0) -> None:
+    def add_edge(
+        self, other: "NodoTNFR", weight: float = 1.0, *, overwrite: bool = False
+    ) -> None:
+        """Conecta este nodo con ``other``.
+
+        Si la arista ya existe, el peso almacenado se conserva a menos que
+        ``overwrite`` sea ``True``, en cuyo caso se actualiza al nuevo
+        ``weight``.
+        """
+
+        if other in self._neighbors and not overwrite:
+            return
         self._neighbors[other] = weight
         other._neighbors[self] = weight
 
@@ -188,8 +201,12 @@ class NodoNX(NodoProtocol):
             return self.G.has_edge(self.n, other.n)
         raise NotImplementedError
 
-    def add_edge(self, other: NodoProtocol, weight: float) -> None:
+    def add_edge(
+        self, other: NodoProtocol, weight: float, *, overwrite: bool = False
+    ) -> None:
         if isinstance(other, NodoNX):
+            if self.G.has_edge(self.n, other.n) and not overwrite:
+                return
             self.G.add_edge(self.n, other.n, weight=float(weight))
         else:
             raise NotImplementedError

--- a/tests/test_node_weights.py
+++ b/tests/test_node_weights.py
@@ -17,3 +17,21 @@ def test_missing_edge_returns_zero():
     b = NodoTNFR()
     assert not a.has_edge(b)
     assert a.edge_weight(b) == 0.0
+
+
+def test_add_edge_preserves_weight_by_default():
+    a = NodoTNFR()
+    b = NodoTNFR()
+    a.add_edge(b, weight=1.0)
+    a.add_edge(b, weight=2.0)
+    assert math.isclose(a.edge_weight(b), 1.0)
+    assert math.isclose(b.edge_weight(a), 1.0)
+
+
+def test_add_edge_overwrite():
+    a = NodoTNFR()
+    b = NodoTNFR()
+    a.add_edge(b, weight=1.0)
+    a.add_edge(b, weight=2.0, overwrite=True)
+    assert math.isclose(a.edge_weight(b), 2.0)
+    assert math.isclose(b.edge_weight(a), 2.0)


### PR DESCRIPTION
## Summary
- prevent silent edge weight overwrites in `NodoTNFR.add_edge`
- mirror logic in `NodoNX.add_edge`
- test preserving and overwriting edge weights

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4b5bbfe6483218b746174d50a1bc8