### PR TITLE
Use dedicated Random instances for node initialization

### DIFF
--- a/src/tnfr/initialization.py
+++ b/src/tnfr/initialization.py
@@ -45,19 +45,16 @@ def init_node_attrs(G: nx.Graph, *, override: bool = True) -> nx.Graph:
     si_max = float(G.graph.get("INIT_SI_MAX", 0.7))
     epi_val = float(G.graph.get("INIT_EPI_VALUE", 0.0))
 
-    rand = random.Random(seed)
-
     for idx, n in enumerate(G.nodes()):
+        rand_i = random.Random(seed + idx)
         nd = G.nodes[n]
 
         if override or "EPI" not in nd:
             nd["EPI"] = epi_val
 
-        rand.seed(seed + idx)
-
         if init_rand_phase:
             if override or "θ" not in nd:
-                nd["θ"] = rand.uniform(th_min, th_max)
+                nd["θ"] = rand_i.uniform(th_min, th_max)
         else:
             if override:
                 nd["θ"] = 0.0
@@ -65,15 +62,15 @@ def init_node_attrs(G: nx.Graph, *, override: bool = True) -> nx.Graph:
                 nd.setdefault("θ", 0.0)
 
         if vf_mode == "uniform":
-            vf = rand.uniform(float(vf_uniform_min), float(vf_uniform_max))
+            vf = rand_i.uniform(float(vf_uniform_min), float(vf_uniform_max))
         elif vf_mode == "normal":
             for _ in range(16):
-                cand = rand.normalvariate(vf_mean, vf_std)
+                cand = rand_i.normalvariate(vf_mean, vf_std)
                 if vf_min_lim <= cand <= vf_max_lim:
                     vf = cand
                     break
             else:
-                vf = min(max(rand.normalvariate(vf_mean, vf_std), vf_min_lim), vf_max_lim)
+                vf = min(max(rand_i.normalvariate(vf_mean, vf_std), vf_min_lim), vf_max_lim)
         else:
             vf = float(nd.get("νf", 0.5))
         if clamp_to_limits:
@@ -81,7 +78,7 @@ def init_node_attrs(G: nx.Graph, *, override: bool = True) -> nx.Graph:
         if override or "νf" not in nd:
             nd["νf"] = float(vf)
 
-        si = rand.uniform(si_min, si_max)
+        si = rand_i.uniform(si_min, si_max)
         if override or "Si" not in nd:
             nd["Si"] = float(si)
 


### PR DESCRIPTION
## Summary
- Ensure deterministic initialization by using a separate `Random` instance seeded with `seed + idx` for each node

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4b933a83c832181803f84afc71151