### PR TITLE
Elimina divisor redundante al calcular sentido de red

### DIFF
--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -113,7 +113,7 @@ def sigma_vector_global(G, weight_mode: str | None = None) -> Dict[str, float]:
         cnt += 1
     if cnt == 0:
         return {"x": 0.0, "y": 0.0, "mag": 0.0, "angle": 0.0, "n": 0}
-    x, y = acc.real / max(1, cnt), acc.imag / max(1, cnt)
+    x, y = acc.real / cnt, acc.imag / cnt
     mag = math.hypot(x, y)
     ang = math.atan2(y, x)
     return {"x": float(x), "y": float(y), "mag": float(mag), "angle": float(ang), "n": cnt}


### PR DESCRIPTION
## Summary
- Reemplaza `max(1, cnt)` por `cnt` después de comprobar `cnt == 0` en `sense.py`.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4b9b314d083218bc24beac5de3dda