### PR TITLE
refactor: replace sigma_vector with sigma_vector_global

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -16,7 +16,8 @@ import math
 from collections import deque
 import networkx as nx
 
-from .observers import sincronía_fase, carga_glifica, orden_kuramoto, sigma_vector
+from .observers import sincronía_fase, carga_glifica, orden_kuramoto
+from .sense import sigma_vector_global
 from .operators import aplicar_remesh_si_estabilizacion_global
 from .grammar import (
     enforce_canonical_grammar,
@@ -835,7 +836,7 @@ def _update_sigma(G, hist) -> None:
     hist["glyph_load_estab"].append(gl.get("_estabilizadores", 0.0))
     hist["glyph_load_disr"].append(gl.get("_disruptivos", 0.0))
 
-    sig = sigma_vector(G, window=win)
+    sig = sigma_vector_global(gl)
     hist.setdefault("sense_sigma_x", []).append(sig.get("x", 0.0))
     hist.setdefault("sense_sigma_y", []).append(sig.get("y", 0.0))
     hist.setdefault("sense_sigma_mag", []).append(sig.get("mag", 0.0))

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -10,7 +10,6 @@ import statistics as st
 
 from .constants import ALIAS_DNFR, ALIAS_EPI, ALIAS_THETA, ALIAS_dEPI
 from .helpers import _get_attr, list_mean, register_callback, angle_diff, ensure_history, count_glyphs
-from .sense import glyph_unit, SIGMA_ANGLE_KEYS
 from .constants_glifos import ESTABILIZADORES, DISRUPTIVOS
 
 # -------------------------
@@ -108,30 +107,6 @@ def carga_glifica(G, window: int | None = None) -> dict:
     dist["_count"] = count
     return dist
 
-def sigma_vector(G, window: int | None = None) -> dict:
-    """Vector de sentido Σ⃗ a partir de la distribución glífica reciente.
-    Devuelve dict con x, y, mag (0..1) y angle (rad)."""
-    # Distribución glífica (proporciones)
-    dist = carga_glifica(G, window=window)
-    if not dist or dist.get("_count", 0) == 0:
-        return {"x": 0.0, "y": 0.0, "mag": 0.0, "angle": 0.0}
-
-    # Usa el conjunto fijo de glifos en el plano de sentido
-    total = sum(dist.get(k, 0.0) for k in SIGMA_ANGLE_KEYS)
-    if total <= 0:
-        return {"x": 0.0, "y": 0.0, "mag": 0.0, "angle": 0.0}
-
-    x = 0.0
-    y = 0.0
-    for k in SIGMA_ANGLE_KEYS:
-        p = dist.get(k, 0.0) / total
-        z = glyph_unit(k)
-        x += p * z.real
-        y += p * z.imag
-
-    mag = math.hypot(x, y)
-    ang = math.atan2(y, x)
-    return {"x": float(x), "y": float(y), "mag": float(mag), "angle": float(ang)}
 
 def wbar(G, window: int | None = None) -> float:
     """Devuelve W̄ = media de C(t) en una ventana reciente."""

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -6,7 +6,8 @@ import pytest
 from tnfr.node import NodoNX
 from tnfr.operators import random_jitter
 from tnfr.constants import ALIAS_THETA
-from tnfr.observers import sincronía_fase, orden_kuramoto, carga_glifica, sigma_vector
+from tnfr.observers import sincronía_fase, orden_kuramoto, carga_glifica
+from tnfr.sense import sigma_vector_global
 from tnfr.constants_glifos import ANGLE_MAP, ESTABILIZADORES, DISRUPTIVOS
 from tnfr.helpers import angle_diff, _set_attr
 
@@ -61,15 +62,11 @@ def test_carga_glifica_uses_module_constants(monkeypatch, graph_canon):
     assert dist["_disruptivos"] == pytest.approx(0.5)
 
 
-def test_sigma_vector_consistency(monkeypatch, graph_canon):
-    import tnfr.observers as obs
-
-    G = graph_canon()
+def test_sigma_vector_consistency():
     # Distribución ficticia de glifos
     dist = {"IL": 0.4, "RA": 0.3, "ZHIR": 0.1, "AL": 0.2, "_count": 10}
-    monkeypatch.setattr(obs, "carga_glifica", lambda G, window=None: dist)
 
-    res = sigma_vector(G)
+    res = sigma_vector_global(dist)
 
     # Cálculo esperado con el mapa de ángulos canónico
     keys = ESTABILIZADORES + DISRUPTIVOS


### PR DESCRIPTION
## Summary
- drop sigma_vector observer and rely on sigma_vector_global
- extend sigma_vector_global to accept pre-counted distributions
- update dynamics and tests to use sigma_vector_global

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4bd4596d083218769a0746ce8cf7e