### PR TITLE
Fix callbacks metadata key

### DIFF
--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -70,14 +70,21 @@ def _trace_before(G, *args, **kwargs):
 
     if "callbacks" in capture:
         # si el motor guarda los callbacks, exponer nombres por fase
-        cb = G.graph.get("_callbacks")
+        cb = G.graph.get("callbacks")
         if isinstance(cb, dict):
             out = {}
             for phase, callbacks in cb.items():
                 if isinstance(callbacks, list):
-                    names = []
-                    for (_, func, *_rest) in callbacks:
-                        names.append(getattr(func, "__name__", "fn"))
+                    names: List[str] = []
+                    for item in callbacks:
+                        if isinstance(item, tuple):
+                            name = item[0]
+                            if not isinstance(name, str):
+                                func = item[1] if len(item) > 1 else None
+                                name = getattr(func, "__name__", "fn")
+                        else:
+                            name = getattr(item, "__name__", "fn")
+                        names.append(name)
                     out[phase] = names
                 else:
                     out[phase] = None
@@ -134,7 +141,7 @@ def register_trace(G) -> None:
       - selector: nombre del selector glífico
       - dnfr_weights: mezcla ΔNFR declarada en el motor
       - si_weights: pesos α/β/γ y sensibilidad de Si
-      - callbacks: callbacks registrados por fase (si están en G.graph['_callbacks'])
+      - callbacks: callbacks registrados por fase (si están en G.graph['callbacks'])
       - thol_open_nodes: cuántos nodos tienen bloque THOL abierto
       - kuramoto: (R, ψ) de la red
       - sigma: vector global del plano del sentido

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,4 +1,5 @@
 from tnfr.trace import register_trace
+from tnfr.helpers import register_callback, invoke_callbacks
 
 
 def test_register_trace_idempotent(graph_canon):
@@ -13,3 +14,19 @@ def test_register_trace_idempotent(graph_canon):
 
     assert list(G.graph["callbacks"]["before_step"]) == before
     assert list(G.graph["callbacks"]["after_step"]) == after
+
+
+def test_trace_metadata_contains_callback_names(graph_canon):
+    G = graph_canon()
+    register_trace(G)
+
+    def foo(G, ctx):
+        pass
+
+    register_callback(G, when="before_step", func=foo, name="custom_cb")
+    invoke_callbacks(G, "before_step")
+
+    hist = G.graph["history"]["trace_meta"]
+    meta = hist[0]
+    assert "callbacks" in meta
+    assert "custom_cb" in meta["callbacks"].get("before_step", [])


### PR DESCRIPTION
## Summary
- read callbacks from `callbacks` graph key and extract stored names
- document new callbacks key in trace metadata
- test callbacks metadata for custom callback names

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4be424b5c8321872f106485b6865f