### PR TITLE
Ensure sigma defaults to zero when glyphs absent

### DIFF
--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -115,7 +115,12 @@ def _trace_after(G, *args, **kwargs):
 
     if "sigma" in capture:
         sv = sigma_vector_global(G)
-        meta["sigma"] = {"x": float(sv.get("x", 1.0)), "y": float(sv.get("y", 0.0)), "mag": float(sv.get("mag", 1.0)), "angle": float(sv.get("angle", 0.0))}
+        meta["sigma"] = {
+            "x": float(sv.get("x", 0.0)),
+            "y": float(sv.get("y", 0.0)),
+            "mag": float(sv.get("mag", 0.0)),
+            "angle": float(sv.get("angle", 0.0)),
+        }
 
     if "glifo_counts" in capture:
         cnt = Counter()

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -30,3 +30,19 @@ def test_trace_metadata_contains_callback_names(graph_canon):
     meta = hist[0]
     assert "callbacks" in meta
     assert "custom_cb" in meta["callbacks"].get("before_step", [])
+
+
+def test_trace_sigma_no_glyphs(graph_canon):
+    G = graph_canon()
+    # add nodes without glifo history
+    G.add_nodes_from([1, 2, 3])
+    register_trace(G)
+    invoke_callbacks(G, "after_step")
+    meta = G.graph["history"]["trace_meta"][0]
+    assert meta["phase"] == "after"
+    assert meta["sigma"] == {
+        "x": 0.0,
+        "y": 0.0,
+        "mag": 0.0,
+        "angle": 0.0,
+    }


### PR DESCRIPTION
## Summary
- Fix trace sigma capture to default to 0.0 for missing `x` and `mag`
- Add regression test for networks without registered glyphs

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4bf044978832182ddbfb177866de5