### PR TITLE
Use glyph set for canonical membership checks

### DIFF
--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 
 from .constants import get_param
 from .grammar import apply_glyph_with_grammar
-from .sense import GLYPHS_CANONICAL
+from .sense import GLYPHS_CANONICAL_SET
 from .types import Glyph
 
 # Tipos básicos
@@ -99,7 +99,7 @@ def _flatten(seq: Sequence[Token]) -> List[Tuple[str, Any]]:
         else:
             # item debería ser un glifo
             g = item.value if isinstance(item, Glyph) else str(item)
-            if g not in GLYPHS_CANONICAL:
+            if g not in GLYPHS_CANONICAL_SET:
                 raise ValueError(f"Glifo no canónico: {g}")
             ops.append(("GLYPH", g))
     return ops

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -34,6 +34,8 @@ GLYPHS_CANONICAL: List[str] = [
     Glyph.REMESH.value #12
 ]
 
+GLYPHS_CANONICAL_SET: set[str] = set(GLYPHS_CANONICAL)
+
 # Glifos relevantes para el plano Σ de observadores de sentido
 SIGMA_ANGLE_KEYS: tuple[str, ...] = tuple(ESTABILIZADORES + DISRUPTIVOS)
 


### PR DESCRIPTION
## Summary
- derive `GLYPHS_CANONICAL_SET` from the canonical glyph list
- use the set in `program._flatten` to validate glyph tokens efficiently

## Testing
- `PYTHONPATH=$PWD/src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4c065eafc83218c02977a78b7dd50