### PR TITLE
Add sigma_vector helper for precomputed distributions

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -18,7 +18,7 @@ from .gamma import GAMMA_REGISTRY, eval_gamma, kuramoto_R_psi
 from .grammar import enforce_canonical_grammar, on_applied_glifo, apply_glyph_with_grammar
 from .sense import (
     GLYPHS_CANONICAL, glyph_angle, glyph_unit,
-    sigma_vector_node, sigma_vector_global,
+    sigma_vector_node, sigma_vector_global, sigma_vector,
     push_sigma_snapshot, sigma_series, sigma_rose,
     register_sigma_callback,
 )
@@ -66,7 +66,7 @@ __all__ = [
     "enforce_canonical_grammar", "on_applied_glifo",
     "apply_glyph_with_grammar",
     "GLYPHS_CANONICAL", "glyph_angle", "glyph_unit",
-    "sigma_vector_node", "sigma_vector_global",
+    "sigma_vector_node", "sigma_vector_global", "sigma_vector",
     "push_sigma_snapshot", "sigma_series", "sigma_rose",
     "register_sigma_callback",
     "register_metrics_callbacks",

--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -17,7 +17,7 @@ from collections import deque
 import networkx as nx
 
 from .observers import sincronía_fase, carga_glifica, orden_kuramoto
-from .sense import sigma_vector_global
+from .sense import sigma_vector
 from .operators import aplicar_remesh_si_estabilizacion_global
 from .grammar import (
     enforce_canonical_grammar,
@@ -836,7 +836,7 @@ def _update_sigma(G, hist) -> None:
     hist["glyph_load_estab"].append(gl.get("_estabilizadores", 0.0))
     hist["glyph_load_disr"].append(gl.get("_disruptivos", 0.0))
 
-    sig = sigma_vector_global(gl)
+    sig = sigma_vector(gl)
     hist.setdefault("sense_sigma_x", []).append(sig.get("x", 0.0))
     hist.setdefault("sense_sigma_y", []).append(sig.get("y", 0.0))
     hist.setdefault("sense_sigma_mag", []).append(sig.get("mag", 0.0))

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -7,7 +7,7 @@ from tnfr.node import NodoNX
 from tnfr.operators import random_jitter
 from tnfr.constants import ALIAS_THETA
 from tnfr.observers import sincronía_fase, orden_kuramoto, carga_glifica
-from tnfr.sense import sigma_vector_global
+from tnfr.sense import sigma_vector_global, sigma_vector
 from tnfr.constants_glifos import ANGLE_MAP, ESTABILIZADORES, DISRUPTIVOS
 from tnfr.helpers import angle_diff, _set_attr
 
@@ -66,7 +66,8 @@ def test_sigma_vector_consistency():
     # Distribución ficticia de glifos
     dist = {"IL": 0.4, "RA": 0.3, "ZHIR": 0.1, "AL": 0.2, "_count": 10}
 
-    res = sigma_vector_global(dist)
+    res_global = sigma_vector_global(dist)
+    res = sigma_vector(dist)
 
     # Cálculo esperado con el mapa de ángulos canónico
     keys = ESTABILIZADORES + DISRUPTIVOS
@@ -77,7 +78,8 @@ def test_sigma_vector_consistency():
     mag = math.hypot(x, y)
     ang = math.atan2(y, x)
 
-    assert math.isclose(res["x"], x)
-    assert math.isclose(res["y"], y)
-    assert math.isclose(res["mag"], mag)
-    assert math.isclose(res["angle"], ang)
+    for res_ in (res_global, res):
+        assert math.isclose(res_["x"], x)
+        assert math.isclose(res_["y"], y)
+        assert math.isclose(res_["mag"], mag)
+        assert math.isclose(res_["angle"], ang)


### PR DESCRIPTION
## Summary
- provide `sigma_vector` to compute Σ⃗ from a precomputed glyph distribution
- delegate `sigma_vector_global` to the new helper when given a distribution
- reuse existing glyph distribution in `_update_sigma`
- extend tests to cover new helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4c314a03083218821bc7e89543ba4