### PR TITLE
Handle zero total when computing latency index

### DIFF
--- a/src/tnfr/metrics.py
+++ b/src/tnfr/metrics.py
@@ -108,7 +108,7 @@ def _update_glifogram(G, hist, counts, t):
 
 def _update_latency_index(G, hist, n_total, n_latent, t):
     """Añade el índice de latencia a la historia."""
-    li = (n_latent / max(1, n_total)) if n_total else 0.0
+    li = n_latent / max(1, n_total)
     hist.setdefault("latency_index", []).append({"t": t, "value": li})
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,5 +1,7 @@
+import networkx as nx
+
 from tnfr.constants import attach_defaults
-from tnfr.metrics import _metrics_step
+from tnfr.metrics import _metrics_step, _update_latency_index
 
 
 def test_pp_val_zero_when_no_remesh(graph_canon):
@@ -44,3 +46,11 @@ def test_save_by_node_flag_keeps_metrics_equal(graph_canon):
     assert hist_true["morph"] == hist_false["morph"]
     assert hist_true["Tg_by_node"] != {}
     assert hist_false.get("Tg_by_node", {}) == {}
+
+
+def test_latency_index_uses_max_denominator():
+    """Latency index uses max(1, n_total) to avoid zero division."""
+    G = nx.Graph()
+    hist = {}
+    _update_latency_index(G, hist, n_total=0, n_latent=2, t=0)
+    assert hist["latency_index"][0]["value"] == 2.0


### PR DESCRIPTION
## Summary
- Simplify latency index calculation to always divide by `max(1, n_total)`
- Add regression test ensuring latency index handles zero totals without division errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4c5ea7b688321865331a1e1da2961