### PR TITLE
Respect empty graphs when creating NFR

### DIFF
--- a/src/tnfr/structural.py
+++ b/src/tnfr/structural.py
@@ -38,7 +38,7 @@ def create_nfr(
 
     Devuelve la tupla ``(G, name)`` para conveniencia.
     """
-    G = graph or nx.Graph()
+    G = graph if graph is not None else nx.Graph()
     G.add_node(
         name,
         **{


### PR DESCRIPTION
## Summary
- Avoid replacing provided empty graphs in create_nfr by checking `graph is not None`

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4c88eb2b48321b4ab751fd4648524