### PR TITLE
Ensure string inputs form tuples in _ensure_tuple

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -104,7 +104,11 @@ _sentinel = object()
 
 def _ensure_tuple(aliases: Iterable[str]) -> tuple[str, ...]:
     """Garantiza que ``aliases`` sea una tupla."""
-    return aliases if isinstance(aliases, tuple) else tuple(aliases)
+    if isinstance(aliases, tuple):
+        return aliases
+    if isinstance(aliases, str):
+        return (aliases,)
+    return tuple(aliases)
 
 
 def alias_get(


### PR DESCRIPTION
## Summary
- Handle string inputs in `_ensure_tuple` to avoid character splitting

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4c91bb0188321a5470a450e0a5465