### PR TITLE
Use class attributes in operator registry

### DIFF
--- a/src/tnfr/structural.py
+++ b/src/tnfr/structural.py
@@ -139,7 +139,7 @@ class Recursividad(Operador):
 
 
 OPERADORES = {
-    op().name: op
+    op.name: op
     for op in [
         Emision,
         Recepcion,


### PR DESCRIPTION
## Summary
- use class attributes to map operator names to classes

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4ca7f89e88321b624e148001ed865