### PR TITLE
Remove inline ontosim example

### DIFF
--- a/examples/ontosim_example.py
+++ b/examples/ontosim_example.py
@@ -1,0 +1,20 @@
+"""Pequeño ejemplo de uso de ``tnfr.ontosim``.
+
+Genera un grafo Erdős–Rényi y ejecuta 100 pasos de la simulación usando los
+valores por defecto.
+"""
+
+import networkx as nx
+
+from tnfr.ontosim import preparar_red, run
+
+
+def main() -> None:
+    G = nx.erdos_renyi_graph(30, 0.15)
+    preparar_red(G)
+    run(G, 100)
+    # print("C(t) muestras:", G.graph["history"]["C_steps"][-5:])  # usado solo para pruebas
+
+
+if __name__ == "__main__":  # pragma: no cover - ejemplo manual
+    main()

--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -78,9 +78,3 @@ def step(G: nx.Graph, *, dt: float | None = None, use_Si: bool = True, apply_gly
 def run(G: nx.Graph, steps: int, *, dt: float | None = None, use_Si: bool = True, apply_glyphs: bool = True) -> None:
     _run(G, steps=steps, dt=dt, use_Si=use_Si, apply_glyphs=apply_glyphs)
 
-# Helper rápido para pruebas manuales
-if __name__ == "__main__":
-    G = nx.erdos_renyi_graph(30, 0.15)
-    preparar_red(G)
-    run(G, 100)
-    # print("C(t) muestras:", G.graph["history"]["C_steps"][-5:])  # usado solo para pruebas


### PR DESCRIPTION
## Summary
- remove `__main__` helper block from `tnfr.ontosim` so module stays import-only
- add dedicated `examples/ontosim_example.py` demonstrating manual usage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4cd9d86bc832192270daafa6f1031