### PR TITLE
Import fmean from statistics

### DIFF
--- a/src/tnfr/metrics.py
+++ b/src/tnfr/metrics.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from typing import Dict, Any, List, Tuple
 from collections import defaultdict, Counter
 import statistics
+from statistics import fmean
 import csv
 import json
 import os
@@ -26,7 +27,6 @@ from .helpers import (
     _get_attr,
     clamp01,
     list_mean,
-    fmean,
 )
 from .sense import GLYPHS_CANONICAL
 


### PR DESCRIPTION
## Summary
- import `fmean` from the standard `statistics` module
- stop re-exporting `fmean` from `helpers`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4cf5b045c832180fd5d1d6b8a07f1