### PR TITLE
Expose attribute helpers publicly

### DIFF
--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -23,7 +23,7 @@ import math
 import cmath
 
 from .constants import ALIAS_THETA
-from .helpers import _get_attr
+from .helpers import get_attr
 
 
 
@@ -54,7 +54,7 @@ def kuramoto_R_psi(G) -> Tuple[float, float]:
     n = 0
     for node in G.nodes():
         nd = G.nodes[node]
-        th = _get_attr(nd, ALIAS_THETA, 0.0)
+        th = get_attr(nd, ALIAS_THETA, 0.0)
         acc += cmath.exp(1j * th)
         n += 1
     if n == 0:
@@ -73,7 +73,7 @@ def _kuramoto_common(G, node, cfg):
     cache = G.graph.get("_kuramoto_cache", {})
     R = float(cache.get("R", 0.0))
     psi = float(cache.get("psi", 0.0))
-    th_i = float(_get_attr(G.nodes[node], ALIAS_THETA, 0.0))
+    th_i = float(get_attr(G.nodes[node], ALIAS_THETA, 0.0))
     return th_i, R, psi
 
 

--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -6,7 +6,7 @@ from .constants import (
     ALIAS_SI, ALIAS_DNFR, ALIAS_EPI,
     get_param,
 )
-from .helpers import _get_attr, clamp01, reciente_glifo
+from .helpers import get_attr, clamp01, reciente_glifo
 from .types import Glyph
 
 # Glifos nominales (para evitar typos)
@@ -63,11 +63,11 @@ def _dnfr_norm(G, nd) -> float:
     # Normalizador robusto: usa historial de |ΔNFR| máx guardado por dynamics (si existe)
     norms = G.graph.get("_sel_norms") or {}
     dmax = float(norms.get("dnfr_max", 1.0)) or 1.0
-    return clamp01(abs(_get_attr(nd, ALIAS_DNFR, 0.0)) / dmax)
+    return clamp01(abs(get_attr(nd, ALIAS_DNFR, 0.0)) / dmax)
 
 
 def _si(G, nd) -> float:
-    return clamp01(_get_attr(nd, ALIAS_SI, 0.5))
+    return clamp01(get_attr(nd, ALIAS_SI, 0.5))
 
 # -------------------------
 # Núcleo: forzar gramática sobre un candidato

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -15,10 +15,10 @@ from .constants import (
 )
 from .helpers import (
     push_glifo,
-    _get_attr,
-    _get_attr_str,
-    _set_attr,
-    _set_attr_str,
+    get_attr,
+    get_attr_str,
+    set_attr,
+    set_attr_str,
     set_vf,
     set_dnfr,
 )
@@ -28,8 +28,8 @@ def _nx_attr_property(
     aliases,
     *,
     default=0.0,
-    getter=_get_attr,
-    setter=_set_attr,
+    getter=get_attr,
+    setter=set_attr,
     to_python=float,
     to_storage=float,
     use_graph_setter=False,
@@ -181,8 +181,8 @@ class NodoNX(NodoProtocol):
     epi_kind = _nx_attr_property(
         ALIAS_EPI_KIND,
         default="",
-        getter=_get_attr_str,
-        setter=_set_attr_str,
+        getter=get_attr_str,
+        setter=set_attr_str,
         to_python=str,
         to_storage=str,
     )

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -9,7 +9,7 @@ import math
 import statistics as st
 
 from .constants import ALIAS_DNFR, ALIAS_EPI, ALIAS_THETA, ALIAS_dEPI
-from .helpers import _get_attr, list_mean, register_callback, angle_diff, ensure_history, count_glyphs
+from .helpers import get_attr, list_mean, register_callback, angle_diff, ensure_history, count_glyphs
 from .constants_glifos import ESTABILIZADORES, DISRUPTIVOS
 
 # -------------------------
@@ -39,15 +39,15 @@ def attach_standard_observer(G):
 
 def coherencia_global(G) -> float:
     """Proxy de C(t): alta cuando |ΔNFR| y |dEPI_dt| son pequeños."""
-    dnfr = list_mean(abs(_get_attr(G.nodes[n], ALIAS_DNFR, 0.0)) for n in G.nodes())
-    dEPI = list_mean(abs(_get_attr(G.nodes[n], ALIAS_dEPI, 0.0)) for n in G.nodes())
+    dnfr = list_mean(abs(get_attr(G.nodes[n], ALIAS_DNFR, 0.0)) for n in G.nodes())
+    dEPI = list_mean(abs(get_attr(G.nodes[n], ALIAS_dEPI, 0.0)) for n in G.nodes())
     return 1.0 / (1.0 + dnfr + dEPI)
 
 
 def _phase_vectors(G) -> tuple[list, list]:
     """Devuelve listas de cosenos y senos de las fases nodales."""
-    X = [math.cos(_get_attr(G.nodes[n], ALIAS_THETA, 0.0)) for n in G.nodes()]
-    Y = [math.sin(_get_attr(G.nodes[n], ALIAS_THETA, 0.0)) for n in G.nodes()]
+    X = [math.cos(get_attr(G.nodes[n], ALIAS_THETA, 0.0)) for n in G.nodes()]
+    Y = [math.sin(get_attr(G.nodes[n], ALIAS_THETA, 0.0)) for n in G.nodes()]
     return X, Y
 
 
@@ -60,7 +60,7 @@ def sincronía_fase(G) -> float:
     var = (
         st.pvariance(
             [
-                angle_diff(_get_attr(G.nodes[n], ALIAS_THETA, 0.0), th)
+                angle_diff(get_attr(G.nodes[n], ALIAS_THETA, 0.0), th)
                 for n in G.nodes()
             ]
         )

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -5,7 +5,7 @@ from collections import Counter
 
 from .constants import ALIAS_SI, ALIAS_EPI, SIGMA
 from .helpers import (
-    _get_attr,
+    get_attr,
     clamp01,
     register_callback,
     ensure_history,
@@ -58,9 +58,9 @@ def glyph_unit(g: str) -> complex:
 def _weight(G, n, mode: str) -> float:
     nd = G.nodes[n]
     if mode == "Si":
-        return clamp01(_get_attr(nd, ALIAS_SI, 0.5))
+        return clamp01(get_attr(nd, ALIAS_SI, 0.5))
     if mode == "EPI":
-        return max(0.0, float(_get_attr(nd, ALIAS_EPI, 0.0)))
+        return max(0.0, float(get_attr(nd, ALIAS_EPI, 0.0)))
     return 1.0
 
 

--- a/src/tnfr/validators.py
+++ b/src/tnfr/validators.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from .constants import ALIAS_EPI, ALIAS_VF, DEFAULTS
-from .helpers import _get_attr
+from .helpers import get_attr
 from .sense import sigma_vector_global, GLYPHS_CANONICAL
 from .helpers import last_glifo
 
@@ -14,10 +14,10 @@ def _validate_epi_vf(G) -> None:
     vmin = float(G.graph.get("VF_MIN", DEFAULTS.get("VF_MIN", 0.0)))
     vmax = float(G.graph.get("VF_MAX", DEFAULTS.get("VF_MAX", 1.0)))
     for n, data in G.nodes(data=True):
-        epi = float(_get_attr(data, ALIAS_EPI, 0.0))
+        epi = float(get_attr(data, ALIAS_EPI, 0.0))
         if not (emin - 1e-9 <= epi <= emax + 1e-9):
             raise ValueError(f"EPI fuera de rango en nodo {n}: {epi}")
-        vf = float(_get_attr(data, ALIAS_VF, 0.0))
+        vf = float(get_attr(data, ALIAS_VF, 0.0))
         if not (vmin - 1e-9 <= vf <= vmax + 1e-9):
             raise ValueError(f"VF fuera de rango en nodo {n}: {vf}")
 

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -9,7 +9,7 @@ from tnfr.constants import ALIAS_THETA
 from tnfr.observers import sincronía_fase, orden_kuramoto, carga_glifica
 from tnfr.sense import sigma_vector_global, sigma_vector
 from tnfr.constants_glifos import ANGLE_MAP, ESTABILIZADORES, DISRUPTIVOS
-from tnfr.helpers import angle_diff, _set_attr
+from tnfr.helpers import angle_diff, set_attr
 
 
 def test_random_jitter_cache_cleared_on_node_removal(graph_canon):
@@ -34,7 +34,7 @@ def test_phase_observers_match_manual_calculation(graph_canon):
     angles = [0.0, math.pi / 2, math.pi]
     for idx, th in enumerate(angles):
         G.add_node(idx)
-        _set_attr(G.nodes[idx], ALIAS_THETA, th)
+        set_attr(G.nodes[idx], ALIAS_THETA, th)
 
     X = [math.cos(th) for th in angles]
     Y = [math.sin(th) for th in angles]

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -8,7 +8,7 @@ from tnfr.constants import (
     ALIAS_VF,
 )
 from tnfr.validators import run_validators
-from tnfr.helpers import _set_attr_str, _set_attr, read_structured_file
+from tnfr.helpers import set_attr_str, set_attr, read_structured_file
 from tnfr.config import load_config
 
 
@@ -21,7 +21,7 @@ def _base_graph():
 def test_validator_epi_range():
     G = _base_graph()
     n0 = list(G.nodes())[0]
-    _set_attr(G.nodes[n0], ALIAS_EPI, 2.0)
+    set_attr(G.nodes[n0], ALIAS_EPI, 2.0)
     with pytest.raises(ValueError):
         run_validators(G)
 
@@ -29,7 +29,7 @@ def test_validator_epi_range():
 def test_validator_vf_range():
     G = _base_graph()
     n0 = list(G.nodes())[0]
-    _set_attr(G.nodes[n0], ALIAS_VF, 2.0)
+    set_attr(G.nodes[n0], ALIAS_VF, 2.0)
     with pytest.raises(ValueError):
         run_validators(G)
 
@@ -48,7 +48,7 @@ def test_validator_sigma_norm(monkeypatch):
 def test_validator_glifo_invalido():
     G = _base_graph()
     n0 = list(G.nodes())[0]
-    _set_attr_str(G.nodes[n0], ALIAS_EPI_KIND, "INVALID")
+    set_attr_str(G.nodes[n0], ALIAS_EPI_KIND, "INVALID")
     with pytest.raises(ValueError):
         run_validators(G)
 


### PR DESCRIPTION
## Summary
- promote internal attribute accessors to public `get_attr`/`set_attr` helpers
- export helpers via `__all__` and update imports across codebase
- adjust tests to use new helper names

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4d3e332588321ad8e29349857a8a3