### PR TITLE
Optimize default ΔNFR computation and add benchmark

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -111,10 +111,20 @@ def default_compute_delta_nfr(G) -> None:
 
     degs = dict(G.degree()) if w_topo != 0 else None
 
-    for n, nd in G.nodes(data=True):
-        th_i = get_attr(nd, ALIAS_THETA, 0.0)
-        epi_i = get_attr(nd, ALIAS_EPI, 0.0)
-        vf_i = get_attr(nd, ALIAS_VF, 0.0)
+    # Precompute local arrays to avoid repeated G.nodes access inside loops
+    nodes = list(G.nodes)
+    idx = {n: i for i, n in enumerate(nodes)}
+    theta = [get_attr(G.nodes[n], ALIAS_THETA, 0.0) for n in nodes]
+    epi = [get_attr(G.nodes[n], ALIAS_EPI, 0.0) for n in nodes]
+    vf = [get_attr(G.nodes[n], ALIAS_VF, 0.0) for n in nodes]
+    cos_th = [math.cos(t) for t in theta]
+    sin_th = [math.sin(t) for t in theta]
+
+    for n in nodes:
+        i = idx[n]
+        th_i = theta[i]
+        epi_i = epi[i]
+        vf_i = vf[i]
 
         x = y = epi_sum = vf_sum = 0.0
         count = 0
@@ -124,12 +134,11 @@ def default_compute_delta_nfr(G) -> None:
             deg_sum = 0.0
 
         for v in G.neighbors(n):
-            nd_v = G.nodes[v]
-            th_v = get_attr(nd_v, ALIAS_THETA, 0.0)
-            x += math.cos(th_v)
-            y += math.sin(th_v)
-            epi_sum += get_attr(nd_v, ALIAS_EPI, epi_i)
-            vf_sum += get_attr(nd_v, ALIAS_VF, vf_i)
+            j = idx[v]
+            x += cos_th[j]
+            y += sin_th[j]
+            epi_sum += epi[j]
+            vf_sum += vf[j]
             if w_topo != 0 and degs is not None:
                 deg_sum += degs.get(v, deg_i)
             count += 1

--- a/tests/test_dynamics_benchmark.py
+++ b/tests/test_dynamics_benchmark.py
@@ -1,0 +1,18 @@
+import time
+import networkx as nx
+
+from tnfr.dynamics import default_compute_delta_nfr
+from tnfr.constants import ALIAS_THETA, ALIAS_EPI, ALIAS_VF
+
+def test_default_compute_delta_nfr_performance():
+    """Simple benchmark to ensure the optimized computation runs quickly."""
+    G = nx.gnp_random_graph(200, 0.1, seed=1)
+    for n in G.nodes:
+        G.nodes[n][ALIAS_THETA] = 0.0
+        G.nodes[n][ALIAS_EPI] = 0.0
+        G.nodes[n][ALIAS_VF] = 0.0
+    start = time.perf_counter()
+    default_compute_delta_nfr(G)
+    duration = time.perf_counter() - start
+    # Should be fast enough on a moderate graph
+    assert duration < 1.0


### PR DESCRIPTION
## Summary
- Precompute theta, EPI, and νf values and trigonometric terms to avoid repeated `G.nodes` lookups in `default_compute_delta_nfr`
- Add simple benchmark ensuring default ΔNFR computation runs within reasonable time

## Testing
- `PYTHONPATH=src pytest tests/test_dynamics_benchmark.py -q`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4d4fd00ac83218da31204c332d815