### PR TITLE
feat: deterministic random jitter without node references

### DIFF
--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -1,33 +1,12 @@
-import gc
 import math
 import statistics as st
 import pytest
 
-from tnfr.node import NodoNX
-from tnfr.operators import random_jitter
 from tnfr.constants import ALIAS_THETA
 from tnfr.observers import sincronía_fase, orden_kuramoto, carga_glifica
 from tnfr.sense import sigma_vector_global, sigma_vector
 from tnfr.constants_glifos import ANGLE_MAP, ESTABILIZADORES, DISRUPTIVOS
 from tnfr.helpers import angle_diff, set_attr
-
-
-def test_random_jitter_cache_cleared_on_node_removal(graph_canon):
-    G = graph_canon()
-    G.add_node(0)
-    n0 = NodoNX(G, 0)
-
-    random_jitter(n0, 0.1)
-    cache = G.graph.get("_rnd_cache")
-    assert cache is not None
-    assert len(cache) == 1
-
-    del n0
-    G.remove_node(0)
-    gc.collect()
-
-    assert len(cache) == 0
-
 
 def test_phase_observers_match_manual_calculation(graph_canon):
     G = graph_canon()

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,0 +1,19 @@
+from tnfr.node import NodoNX
+from tnfr.operators import random_jitter
+
+
+def test_random_jitter_deterministic_with_and_without_cache(graph_canon):
+    G = graph_canon()
+    G.add_node(0)
+    n0 = NodoNX(G, 0)
+
+    # Without cache
+    j1 = random_jitter(n0, 0.5)
+    j2 = random_jitter(n0, 0.5)
+    assert j1 == j2
+
+    # With explicit cache
+    cache = {}
+    j3 = random_jitter(n0, 0.5, cache)
+    j4 = random_jitter(n0, 0.5, cache)
+    assert j3 == j4 == j1


### PR DESCRIPTION
## Summary
- derive jitter seeds from `(RANDOM_SEED, node.offset())` without storing node refs
- update OZ and NAV operators to use new jitter with optional cache
- add tests to ensure jitter determinism with and without caching

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b4db581a1483219e017b96cb9ba43d