### PR TITLE
Refactor CLI argument parsing and add nested option tests

### DIFF
--- a/tests/test_cli_sanity.py
+++ b/tests/test_cli_sanity.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
-from tnfr.cli import main
+import argparse
+from tnfr.cli import main, add_common_args, add_grammar_args, _build_graph_from_args
+from tnfr.constants import METRIC_DEFAULTS
 from tnfr.helpers import read_structured_file
 from tnfr import __version__
 
@@ -30,3 +32,24 @@ def test_cli_version(capsys):
 def test_cli_run_erdos_p():
     rc = main(["run", "--topology", "erdos", "--p", "0.9", "--nodes", "5", "--steps", "1"])
     assert rc == 0
+
+
+def test_args_to_dict_nested_options():
+    parser = argparse.ArgumentParser()
+    add_common_args(parser)
+    add_grammar_args(parser)
+    args = parser.parse_args(
+        [
+            "--nodes",
+            "5",
+            "--grammar.enabled",
+            "true",
+            "--grammar.thol_min_len",
+            "7",
+        ]
+    )
+    G = _build_graph_from_args(args)
+    canon = G.graph["GRAMMAR_CANON"]
+    assert canon["enabled"] is True
+    assert canon["thol_min_len"] == 7
+    assert METRIC_DEFAULTS["GRAMMAR_CANON"]["thol_min_len"] == 2


### PR DESCRIPTION
## Summary
- simplify `_args_to_dict` using dictionary comprehension and `startswith`
- document `_args_to_dict` behavior with examples
- add CLI test covering nested grammar options and protecting global defaults
- ensure `_build_graph_from_args` assigns fresh grammar settings rather than mutating defaults

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4dcb3585883219d3d07cedd3b3bb1