### PR TITLE
chore: ensure typing imports in trace module

### DIFF
--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
-from typing import Any, Dict, List, Optional
 from collections import Counter
+from typing import Any, Dict, List, Optional
 
 from .constants import TRACE
 from .helpers import register_callback, ensure_history, last_glifo


### PR DESCRIPTION
## Summary
- place `from __future__ import annotations` and typing imports at the top of `trace.py`

## Testing
- `PYTHONPATH=src pytest tests/test_trace.py`

------
https://chatgpt.com/codex/tasks/task_e_68b4e079c15883218534a43d4cca7eef