### PR TITLE
Handle empty aliases in helper functions

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -154,6 +154,8 @@ def alias_get(
     ``default`` convertido (o ``None`` si ``default`` es ``None``).
     """
     aliases = _ensure_tuple(aliases)
+    if not aliases:
+        raise ValueError("'aliases' must contain at least one key")
     for key in aliases:
         if key in d:
             try:
@@ -175,6 +177,8 @@ def alias_set(
 ) -> T:
     """Asigna ``value`` convertido a la primera clave disponible de ``aliases``."""
     aliases = _ensure_tuple(aliases)
+    if not aliases:
+        raise ValueError("'aliases' must contain at least one key")
     for key in aliases:
         if key in d:
             d[key] = conv(value)


### PR DESCRIPTION
## Summary
- Raise `ValueError` when `aliases` iterable is empty in `alias_get` and `alias_set`
- Propagate the check through attribute helper wrappers

## Testing
- `PYTHONPATH=src pytest tests/test_alias_get_default.py tests/test_alias_helpers_threadsafe.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4e20df39083218d4056877312043c