### PR TITLE
Add configurable limit for program trace

### DIFF
--- a/src/tnfr/constants.py
+++ b/src/tnfr/constants.py
@@ -110,6 +110,7 @@ class CoreDefaults:
     )
     CALLBACKS_STRICT: bool = False
     VALIDATORS_STRICT: bool = False
+    PROGRAM_TRACE_MAXLEN: int = 50
 
 
 @dataclass(frozen=True)

--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Union
 from dataclasses import dataclass
 from contextlib import contextmanager
+from collections import deque
 
 from .constants import get_param
 from .grammar import apply_glyph_with_grammar
@@ -122,9 +123,12 @@ def play(G, sequence: Sequence[Token], step_fn: Optional[AdvanceFn] = None) -> N
     curr_target: Optional[Iterable[Node]] = None
 
     # Traza de programa en history
-    if "history" not in G.graph:
-        G.graph["history"] = {}
-    trace = G.graph["history"].setdefault("program_trace", [])
+    history = G.graph.setdefault("history", {})
+    maxlen = int(get_param(G, "PROGRAM_TRACE_MAXLEN"))
+    trace = history.get("program_trace")
+    if not isinstance(trace, deque) or trace.maxlen != maxlen:
+        trace = deque(trace or [], maxlen=maxlen)
+        history["program_trace"] = trace
 
     for op, payload in ops:
         if op == "TARGET":


### PR DESCRIPTION
## Summary
- add `PROGRAM_TRACE_MAXLEN` default constant
- cap `program_trace` using `collections.deque` in `play`

## Testing
- `PYTHONPATH=src pytest 'tests/test_program.py::test_play_records_program_trace_with_block_and_wait' -q`
- `PYTHONPATH=src pytest tests/test_program.py::test_program_trace_limit -q` *(fails: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4e5fd1d088321be6b5e6263c01ae9