### PR TITLE
refactor: remove unused imports

### DIFF
--- a/src/tnfr/metrics.py
+++ b/src/tnfr/metrics.py
@@ -10,7 +10,6 @@ import heapq
 from math import cos
 
 from .constants import (
-    DEFAULTS,
     METRIC_DEFAULTS,
     ALIAS_EPI,
     ALIAS_THETA,
@@ -27,7 +26,6 @@ from .helpers import (
     last_glifo,
     get_attr,
     clamp01,
-    list_mean,
 )
 from .sense import GLYPHS_CANONICAL
 


### PR DESCRIPTION
## Summary
- drop unused DEFAULTS and list_mean imports from metrics

## Testing
- `pyflakes src/tnfr/metrics.py`

------
https://chatgpt.com/codex/tasks/task_e_68b4f0b743708321a1f7d5b1a6a8330e