### PR TITLE
chore: remove unused DEFAULTS import

### DIFF
--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import networkx as nx
 from collections import deque
 
-from .constants import DEFAULTS, METRIC_DEFAULTS, attach_defaults, get_param
+from .constants import METRIC_DEFAULTS, attach_defaults, get_param
 from .dynamics import step as _step, run as _run
 from .dynamics import default_compute_delta_nfr
 from .initialization import init_node_attrs


### PR DESCRIPTION
## Summary
- clean ontosim imports by dropping unused DEFAULTS

## Testing
- `pyflakes src/tnfr/ontosim.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4f14fa0588321b697bedf4cbf3dc6