### PR TITLE
chore: remove unused math import

### DIFF
--- a/src/tnfr/initialization.py
+++ b/src/tnfr/initialization.py
@@ -3,7 +3,6 @@
 Lógica compartida para inicializar atributos nodales básicos (EPI, θ, νf y Si).
 """
 from __future__ import annotations
-import math
 import random
 import networkx as nx
 


### PR DESCRIPTION
## Summary
- remove unused math import from initialization

## Testing
- `pyflakes src/tnfr/initialization.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4f339b03483218c97b225e2460395