### PR TITLE
chore: log Tg_global and cleanup import

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -11,7 +11,7 @@ import networkx as nx
 logger = logging.getLogger(__name__)
 
 from .constants import inject_defaults, DEFAULTS, METRIC_DEFAULTS
-from .sense import register_sigma_callback, sigma_series, sigma_rose
+from .sense import register_sigma_callback, sigma_rose
 from .metrics import (
     register_metrics_callbacks,
     Tg_global,
@@ -243,6 +243,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     if args.summary:
         tg = Tg_global(G, normalize=True)
         lat = latency_series(G)
+        logger.info("Tg global: %s", tg)
         logger.info("Top operadores por Tg: %s", glyph_top(G, k=5))
         if lat["value"]:
             logger.info(


### PR DESCRIPTION
## Summary
- remove unused `sigma_series` import
- log `Tg_global` in run summary

## Testing
- `pyflakes src/tnfr/cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4f3a0e0e883219e4b786a68839bde