### PR TITLE
chore: cleanup tests imports

### DIFF
--- a/tests/test_read_structured_file_errors.py
+++ b/tests/test_read_structured_file_errors.py
@@ -34,7 +34,7 @@ def test_read_structured_file_corrupt_json(tmp_path: Path):
 
 
 def test_read_structured_file_corrupt_yaml(tmp_path: Path):
-    yaml = pytest.importorskip("yaml")
+    pytest.importorskip("yaml")
     path = tmp_path / "bad.yaml"
     path.write_text("a: [1, 2", encoding="utf-8")
     with pytest.raises(ValueError) as excinfo:

--- a/tests/test_sense.py
+++ b/tests/test_sense.py
@@ -1,4 +1,3 @@
-import math
 import networkx as nx
 import pytest
 


### PR DESCRIPTION
## Summary
- remove unused yaml assignment in test_read_structured_file_errors
- drop unused math import in test_sense

## Testing
- `python -m pyflakes tests`

------
https://chatgpt.com/codex/tasks/task_e_68b4f43d5f1c8321a370c3c3b0acc901