### PR TITLE
Simplify Tg update by removing lookup dictionary

### DIFF
--- a/src/tnfr/metrics.py
+++ b/src/tnfr/metrics.py
@@ -62,18 +62,11 @@ def _update_tg(G, hist, dt, save_by_node: bool):
     tg_total = hist.setdefault("Tg_total", defaultdict(float))
     tg_by_node = hist.setdefault("Tg_by_node", {})
 
-    lookups = {
-        "last": last_glifo,
-        "state": _tg_state,
-        "latent": "SHA",
-        "curr": "curr",
-        "run": "run",
-    }
-    last = lookups["last"]
-    tg_state = lookups["state"]
-    latent = lookups["latent"]
-    curr_key = lookups["curr"]
-    run_key = lookups["run"]
+    last = last_glifo
+    tg_state = _tg_state
+    latent = "SHA"
+    curr_key = "curr"
+    run_key = "run"
 
     for n, nd in G.nodes(data=True):
         g = last(nd)


### PR DESCRIPTION
## Summary
- Replace `_update_tg` lookup dictionary with direct variable assignments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4f4e59948832183385e3ed5704d5a