### PR TITLE
Use Random for deterministic jitter

### DIFF
--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -12,8 +12,14 @@ def test_random_jitter_deterministic_with_and_without_cache(graph_canon):
     j2 = random_jitter(n0, 0.5)
     assert j1 == j2
 
-    # With explicit cache
+    # With explicit cache: sequence should be deterministic
     cache = {}
     j3 = random_jitter(n0, 0.5, cache)
     j4 = random_jitter(n0, 0.5, cache)
-    assert j3 == j4 == j1
+    assert j3 == j1
+    assert j4 != j3
+
+    # Replaying with a fresh cache reproduces the sequence
+    cache2 = {}
+    seq = [random_jitter(n0, 0.5, cache2) for _ in range(2)]
+    assert seq == [j3, j4]


### PR DESCRIPTION
## Summary
- Replace SHA-256 jitter seed with `random.Random` seeded by `(seed, key)`
- Cache RNG instances to preserve deterministic noise sequences
- Adapt unit test to cover new sequential jitter behavior

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4fae83d00832197c818b7e55391e7