### PR TITLE
Limit UM candidate search via proximity or sampling

### DIFF
--- a/src/tnfr/constants.py
+++ b/src/tnfr/constants.py
@@ -51,6 +51,8 @@ class CoreDefaults:
         }
     )
     UM_COMPAT_THRESHOLD: float = 0.75
+    UM_CANDIDATE_MODE: str = "sample"
+    UM_CANDIDATE_COUNT: int = 0
     GLYPH_HYSTERESIS_WINDOW: int = 7
     AL_MAX_LAG: int = 5
     EN_MAX_LAG: int = 3

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -1,5 +1,8 @@
 from tnfr.node import NodoNX
 from tnfr.operators import random_jitter
+from tnfr.operators import op_UM
+from tnfr.constants import attach_defaults
+import networkx as nx
 
 
 def test_random_jitter_deterministic_with_and_without_cache(graph_canon):
@@ -23,3 +26,21 @@ def test_random_jitter_deterministic_with_and_without_cache(graph_canon):
     cache2 = {}
     seq = [random_jitter(n0, 0.5, cache2) for _ in range(2)]
     assert seq == [j3, j4]
+
+
+def test_um_candidate_subset_proximity():
+    G = nx.Graph()
+    attach_defaults(G)
+    for i, th in enumerate([0.0, 0.1, 0.2, 1.0]):
+        G.add_node(i, **{"θ": th, "EPI": 0.5, "Si": 0.5})
+
+    G.graph["UM_FUNCTIONAL_LINKS"] = True
+    G.graph["UM_COMPAT_THRESHOLD"] = -1.0
+    G.graph["UM_CANDIDATE_COUNT"] = 2
+    G.graph["UM_CANDIDATE_MODE"] = "proximity"
+
+    op_UM(G, 0)
+
+    assert G.has_edge(0, 1)
+    assert G.has_edge(0, 2)
+    assert not G.has_edge(0, 3)


### PR DESCRIPTION
## Summary
- add `UM_CANDIDATE_MODE` and `UM_CANDIDATE_COUNT` defaults
- reduce UM functional link search to proximity or deterministic sample
- test proximity subset behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b4fd0b3d908321b66479c87175a315