### PR TITLE
Refactor ΔNFR precomputación común

### DIFF
--- a/tests/test_dnfr_precompute.py
+++ b/tests/test_dnfr_precompute.py
@@ -1,0 +1,27 @@
+import pytest
+import networkx as nx
+
+from tnfr.dynamics import _prepare_dnfr_data, _compute_dnfr_numpy, _compute_dnfr_loops
+from tnfr.constants import ALIAS_THETA, ALIAS_EPI, ALIAS_VF, ALIAS_DNFR
+from tnfr.helpers import get_attr
+
+
+def _setup_graph():
+    G = nx.path_graph(5)
+    for n in G.nodes:
+        G.nodes[n][ALIAS_THETA] = 0.1 * (n + 1)
+        G.nodes[n][ALIAS_EPI] = 0.2 * (n + 1)
+        G.nodes[n][ALIAS_VF] = 0.3 * (n + 1)
+    G.graph["DNFR_WEIGHTS"] = {"phase": 0.4, "epi": 0.3, "vf": 0.2, "topo": 0.1}
+    return G
+
+
+def test_strategies_share_precomputed_data():
+    pytest.importorskip("numpy")
+    G = _setup_graph()
+    data = _prepare_dnfr_data(G)
+    _compute_dnfr_loops(G, data)
+    dnfr_loop = [get_attr(G.nodes[n], ALIAS_DNFR, 0.0) for n in G.nodes]
+    _compute_dnfr_numpy(G, data)
+    dnfr_vec = [get_attr(G.nodes[n], ALIAS_DNFR, 0.0) for n in G.nodes]
+    assert dnfr_loop == pytest.approx(dnfr_vec)


### PR DESCRIPTION
## Summary
- Centralize shared ΔNFR data preparation
- Provide numpy and loop strategies consuming precomputed inputs
- Add test ensuring both strategies reuse shared data

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5000f43008321a50dc1eab9e53c15