### PR TITLE
Centralize version in pyproject and document contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Guía de contribución
+
+Gracias por tu interés en contribuir a **TNFR**.
+
+## Versión del proyecto
+
+La versión oficial del proyecto se define **solo** en [`pyproject.toml`](./pyproject.toml) dentro de la sección `[project]`.
+
+- `package.json` no incluye un campo `version`; cualquier build de Node debe consultar `pyproject.toml` si necesita el número de versión.
+- No agregues valores de versión en otros archivos.
+
+## Flujo de trabajo
+
+1. Crea un *fork* y una rama para tu cambio.
+2. Instala las dependencias de Python y ejecuta las pruebas:
+   ```bash
+   pip install -e .[dev]
+   pytest
+   ```
+3. Asegúrate de que tus cambios sigan la estructura del proyecto y estén cubiertos por pruebas cuando sea posible.
+4. Abre un *pull request* describiendo brevemente tu contribución.
+
+¡Gracias por ayudar a mejorar TNFR!

--- a/meta.json
+++ b/meta.json
@@ -2,7 +2,6 @@
   "name": "TNFR — Teoria de la Naturaleza Fractal Resonante",
   "shortName": "TNFR",
   "language": "en",
-  "version": "4.5.2",
   "license": "MIT",
   "description": "TNFR is an operational framework that models reality as coherent reorganization rather than fixed substances. Forms that persist (cells, ideas, teams, emotional states) do so because they resonate — they share structure, rhythm and phase with their environment. TNFR provides a practical grammar (structural operators) and a nodal equation to design, stabilize, transform or collapse forms in a controlled way.",
   "summary": "Design-by-coherence: use structural frequency, phase and nodal gradients to activate and stabilize forms (EPI) across scales, from personal routines to teams, products and curricula.",

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "teoria-de-la-naturaleza-fractal-resonante-tnfr",
+  "license": "MIT",
+  "private": true,
+  "scripts": {
+    "build": "remix vite:build",
+    "test": "pytest"
+  },
+  "devDependencies": {
+    "@remix-run/dev": "^2.17.0",
+    "@remix-run/vite": "npm:@remix-run/dev@^2.17.0"
+  }
+}


### PR DESCRIPTION
## Summary
- remove duplicate version metadata from Node config and project metadata
- add CONTRIBUTING guide stating version lives only in pyproject

## Testing
- `pip install -e .`
- `pytest`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b50d98dd3483219c0d102b973b076f