### PR TITLE
Simplify grammar state initialization

### DIFF
--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -22,10 +22,7 @@ def _gram_state(nd: Dict[str, Any]) -> Dict[str, Any]:
       - thol_open (bool)
       - thol_len (int)
     """
-    st = nd.setdefault("_GRAM", {"thol_open": False, "thol_len": 0})
-    st.setdefault("thol_open", False)
-    st.setdefault("thol_len", 0)
-    return st
+    return nd.setdefault("_GRAM", {"thol_open": False, "thol_len": 0})
 
 # -------------------------
 # Compatibilidades canónicas (siguiente permitido)


### PR DESCRIPTION
## Summary
- Simplify `_gram_state` by using a single `setdefault` call

## Testing
- `pytest -q` *(fails: ImportError: cannot import name '__version__' from partially initialized module 'tnfr')*

------
https://chatgpt.com/codex/tasks/task_e_68b5121fcbc88321a22c8d0ee5ea69e8