### PR TITLE
Warn when NumPy is missing and use non-vectorized fallback

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -23,8 +23,8 @@ logger = logging.getLogger(__name__)
 try:  # Optional dependency
     import numpy as np  # type: ignore
 except ImportError:  # pragma: no cover - handled gracefully
-    logger.error(
-        "Fallo al importar numpy, el modo vectorizado no estará disponible",
+    logger.warning(
+        "Fallo al importar numpy, se continuará con el modo no vectorizado",
         exc_info=True,
     )
     np = None  # type: ignore


### PR DESCRIPTION
## Summary
- Downgrade NumPy import failure from error to warning
- Clarify log message that dynamics will run in non-vectorized mode when NumPy is unavailable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b519c666ec8321985e6382acc8bbf1