### PR TITLE
refactor: ensure normalize_weights uses list of keys

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -145,9 +145,10 @@ def normalize_weights(dict_like: Dict[str, Any], keys: Iterable[str], default: f
     Si la suma de los valores obtenidos es <= 0, se asignan proporciones
     uniformes entre todas las claves.
     """
+    keys = list(keys)
     weights = {k: float(dict_like.get(k, default)) for k in keys}
     total = sum(weights.values())
-    n = len(weights)
+    n = len(keys)
     if total <= 0:
         if n == 0:
             return {}


### PR DESCRIPTION
## Summary
- avoid multiple iterations by converting `keys` to a list before building weight dict
- reuse the list for uniform fallback and normalization

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b51c59d5ac8321857af41280f71fee