### PR TITLE
Use forward iteration for THOL repeats

### DIFF
--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -110,7 +110,7 @@ def _flatten(seq: Sequence[Token]) -> List[Tuple[str, Any]]:
 
             # Insertamos los cuerpos en orden para que la primera repetición
             # sea procesada antes.
-            for _ in reversed(range(repeats)):
+            for _ in range(repeats):
                 for tok in reversed(item.body):
                     stack.append(tok)
             continue


### PR DESCRIPTION
## Summary
- iterate THOL block repetitions with `range` instead of `reversed(range)`
- ensure THOL sequences still expand in the proper order

## Testing
- `pytest tests/test_program.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b51e0556048321a4a57c45b4c6a6bb