### PR TITLE
refactor: reuse token map in sequence loader

### DIFF
--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -56,3 +56,18 @@ def test_load_sequence_json_yaml(tmp_path):
     expected = seq("AL", block("OZ", "EN", "RA"), wait(1))
     assert _load_sequence(jpath) == expected
     assert _load_sequence(ypath) == expected
+
+
+def test_load_sequence_repeated_calls(tmp_path):
+    data = [
+        "AL",
+        {"THOL": {"body": [["OZ", "EN"], "RA"], "repeat": 1}},
+        {"WAIT": 1},
+    ]
+
+    path = tmp_path / "prog.json"
+    path.write_text(json.dumps(data))
+
+    expected = seq("AL", block("OZ", "EN", "RA"), wait(1))
+    for _ in range(5):
+        assert _load_sequence(path) == expected


### PR DESCRIPTION
## Summary
- make `TOKEN_MAP` a module-level constant and expose reusable `_parse_tokens`
- simplify `_load_sequence` to use the global token map
- add regression test exercising repeated `_load_sequence` calls

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b51f0201f48321a301f19a7ddd3986