### PR TITLE
Refactor CLI history persistence

### DIFF
--- a/tests/test_cli_history.py
+++ b/tests/test_cli_history.py
@@ -1,0 +1,20 @@
+from tnfr.cli import main
+import json
+
+
+def test_cli_run_save_history(tmp_path):
+    path = tmp_path / "non" / "existing" / "hist.json"
+    assert not path.parent.exists()
+    rc = main(["run", "--nodes", "5", "--steps", "0", "--save-history", str(path)])
+    assert rc == 0
+    data = json.loads(path.read_text())
+    assert isinstance(data, dict)
+
+
+def test_cli_run_export_history(tmp_path):
+    base = tmp_path / "other" / "history"
+    assert not base.parent.exists()
+    rc = main(["run", "--nodes", "5", "--steps", "0", "--export-history-base", str(base)])
+    assert rc == 0
+    data = json.loads((base.with_suffix(".json")).read_text())
+    assert isinstance(data, dict)


### PR DESCRIPTION
## Summary
- add helper to create parent directories before persisting history
- ensure CLI history saving handles non-serializable deques
- add tests for CLI history save and export options

## Testing
- `PYTHONPATH=src pytest tests/test_cli_history.py tests/test_cli_sanity.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b51fcaaed883218446e8597769325e