### PR TITLE
Add strict validation to alias_get with logging

### DIFF
--- a/src/tnfr/validators.py
+++ b/src/tnfr/validators.py
@@ -14,10 +14,10 @@ def _validate_epi_vf(G) -> None:
         for k in ("EPI_MIN", "EPI_MAX", "VF_MIN", "VF_MAX")
     }
     for n, data in G.nodes(data=True):
-        epi = float(get_attr(data, ALIAS_EPI, 0.0))
+        epi = float(get_attr(data, ALIAS_EPI, 0.0, strict=True))
         if not (cfg["EPI_MIN"] - 1e-9 <= epi <= cfg["EPI_MAX"] + 1e-9):
             raise ValueError(f"EPI fuera de rango en nodo {n}: {epi}")
-        vf = float(get_attr(data, ALIAS_VF, 0.0))
+        vf = float(get_attr(data, ALIAS_VF, 0.0, strict=True))
         if not (cfg["VF_MIN"] - 1e-9 <= vf <= cfg["VF_MAX"] + 1e-9):
             raise ValueError(f"VF fuera de rango en nodo {n}: {vf}")
 

--- a/tests/test_alias_get_strict.py
+++ b/tests/test_alias_get_strict.py
@@ -1,0 +1,16 @@
+import pytest
+from tnfr.helpers import alias_get
+
+
+def test_alias_get_logs_on_error(caplog):
+    d = {"x": "abc"}
+    with caplog.at_level("WARNING"):
+        result = alias_get(d, ["x"], int)
+    assert result is None
+    assert any("No se pudo convertir" in m for m in caplog.messages)
+
+
+def test_alias_get_strict_raises():
+    d = {"x": "abc"}
+    with pytest.raises(ValueError):
+        alias_get(d, ["x"], int, strict=True)


### PR DESCRIPTION
## Summary
- log conversion failures in alias_get and optionally re-raise when strict
- allow get_attr/get_attr_str to request strict validation and use it in validators
- cover new strict and logging behaviour with tests

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5247f51988321bdb5262ba2b3bc2d