### PR TITLE
Refactor RNG usage in initialization and add reproducibility test

### DIFF
--- a/src/tnfr/initialization.py
+++ b/src/tnfr/initialization.py
@@ -50,8 +50,11 @@ def init_node_attrs(G: nx.Graph, *, override: bool = True) -> nx.Graph:
     si_max = float(G.graph.get("INIT_SI_MAX", 0.7))
     epi_val = float(G.graph.get("INIT_EPI_VALUE", 0.0))
 
+    rng = random.Random(seed)
+
     for idx, n in enumerate(G.nodes()):
-        rand_i = random.Random(seed + idx)
+        state = rng.getstate()
+        rng.seed(seed + idx)
         nd = G.nodes[n]
 
         if override or "EPI" not in nd:
@@ -59,7 +62,7 @@ def init_node_attrs(G: nx.Graph, *, override: bool = True) -> nx.Graph:
 
         if init_rand_phase:
             if override or "θ" not in nd:
-                nd["θ"] = rand_i.uniform(th_min, th_max)
+                nd["θ"] = rng.uniform(th_min, th_max)
         else:
             if override:
                 nd["θ"] = 0.0
@@ -67,15 +70,15 @@ def init_node_attrs(G: nx.Graph, *, override: bool = True) -> nx.Graph:
                 nd.setdefault("θ", 0.0)
 
         if vf_mode == "uniform":
-            vf = rand_i.uniform(float(vf_uniform_min), float(vf_uniform_max))
+            vf = rng.uniform(float(vf_uniform_min), float(vf_uniform_max))
         elif vf_mode == "normal":
             for _ in range(16):
-                cand = rand_i.normalvariate(vf_mean, vf_std)
+                cand = rng.normalvariate(vf_mean, vf_std)
                 if vf_min_lim <= cand <= vf_max_lim:
                     vf = cand
                     break
             else:
-                vf = min(max(rand_i.normalvariate(vf_mean, vf_std), vf_min_lim), vf_max_lim)
+                vf = min(max(rng.normalvariate(vf_mean, vf_std), vf_min_lim), vf_max_lim)
         else:
             vf = float(nd.get("νf", 0.5))
         if clamp_to_limits:
@@ -83,8 +86,10 @@ def init_node_attrs(G: nx.Graph, *, override: bool = True) -> nx.Graph:
         if override or "νf" not in nd:
             nd["νf"] = float(vf)
 
-        si = rand_i.uniform(si_min, si_max)
+        si = rng.uniform(si_min, si_max)
         if override or "Si" not in nd:
             nd["Si"] = float(si)
+
+        rng.setstate(state)
 
     return G

--- a/tests/test_initialization.py
+++ b/tests/test_initialization.py
@@ -1,0 +1,21 @@
+import networkx as nx
+
+from tnfr.initialization import init_node_attrs
+from tnfr.constants import attach_defaults
+
+
+def test_init_node_attrs_reproducible():
+    seed = 123
+    G1 = nx.path_graph(5)
+    attach_defaults(G1)
+    G1.graph["RANDOM_SEED"] = seed
+    init_node_attrs(G1)
+    attrs1 = {n: (d["EPI"], d["θ"], d["νf"], d["Si"]) for n, d in G1.nodes(data=True)}
+
+    G2 = nx.path_graph(5)
+    attach_defaults(G2)
+    G2.graph["RANDOM_SEED"] = seed
+    init_node_attrs(G2)
+    attrs2 = {n: (d["EPI"], d["θ"], d["νf"], d["Si"]) for n, d in G2.nodes(data=True)}
+
+    assert attrs1 == attrs2


### PR DESCRIPTION
## Summary
- reuse a single `random.Random` seeded once for node attribute initialization
- seed the RNG per node for deterministic attribute values
- add test to ensure initialization is reproducible given the same seed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5259348b083218f72a0abcb65e53c