### PR TITLE
refactor: reuse kuramoto_R_psi in orden_kuramoto

### DIFF
--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -8,8 +8,16 @@ import math
 import statistics as st
 
 from .constants import ALIAS_DNFR, ALIAS_THETA, ALIAS_dEPI, METRIC_DEFAULTS
-from .helpers import get_attr, list_mean, register_callback, angle_diff, ensure_history, count_glyphs
+from .helpers import (
+    get_attr,
+    list_mean,
+    register_callback,
+    angle_diff,
+    ensure_history,
+    count_glyphs,
+)
 from .constants_glifos import ESTABILIZADORES, DISRUPTIVOS
+from .gamma import kuramoto_R_psi
 
 # -------------------------
 # Observador estándar Γ(R)
@@ -80,10 +88,9 @@ def sincronía_fase(G) -> float:
 
 def orden_kuramoto(G) -> float:
     """R en [0,1], 1 = fases perfectamente alineadas."""
-    sumX, sumY, count = _phase_sums(G)
-    if count == 0:
+    if G.number_of_nodes() == 0:
         return 1.0
-    R = ((sumX**2 + sumY**2) ** 0.5) / max(1, count)
+    R, _ = kuramoto_R_psi(G)
     return float(R)
 
 def carga_glifica(G, window: int | None = None) -> dict:

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -4,6 +4,7 @@ import pytest
 
 from tnfr.constants import ALIAS_THETA
 from tnfr.observers import sincronía_fase, orden_kuramoto, carga_glifica
+from tnfr.gamma import kuramoto_R_psi
 from tnfr.sense import sigma_vector_global, sigma_vector
 from tnfr.constants_glifos import ANGLE_MAP, ESTABILIZADORES, DISRUPTIVOS
 from tnfr.helpers import angle_diff, set_attr
@@ -24,6 +25,18 @@ def test_phase_observers_match_manual_calculation(graph_canon):
 
     R = ((sum(X) ** 2 + sum(Y) ** 2) ** 0.5) / len(angles)
     assert math.isclose(orden_kuramoto(G), float(R))
+
+
+def test_orden_kuramoto_matches_kuramoto_R_psi(graph_canon):
+    G = graph_canon()
+    angles = [0.1, 1.5, 2.9]
+    for idx, th in enumerate(angles):
+        G.add_node(idx)
+        set_attr(G.nodes[idx], ALIAS_THETA, th)
+
+    R_ok = orden_kuramoto(G)
+    R, _ = kuramoto_R_psi(G)
+    assert math.isclose(R_ok, R)
 
 
 def test_carga_glifica_uses_module_constants(monkeypatch, graph_canon):


### PR DESCRIPTION
## Summary
- delegate `orden_kuramoto` to `kuramoto_R_psi` and keep empty-graph fallback
- add regression test comparing both implementations

## Testing
- `pytest tests/test_observers.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5273ead20832196c01ae0028a65c3