### PR TITLE
feat: add last-only option to glyph counting

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -396,25 +396,23 @@ def last_glifo(nd: Dict[str, Any]) -> str | None:
         return None
 
 
-def _count_last_glifos(G) -> Counter:
-    """Cuenta solo el último glifo de cada nodo."""
-    counts: Counter[str] = Counter()
-    for _, nd in G.nodes(data=True):
-        g = last_glifo(nd)
-        if g:
-            counts[g] += 1
-    return counts
-
-
-def count_glyphs(G, window: int | None = None) -> Counter:
+def count_glyphs(
+    G, window: int | None = None, *, last_only: bool = False
+) -> Counter:
     """Cuenta glifos recientes en la red.
 
-    Si ``window`` es ``1`` cuenta solo el último glifo de cada nodo. Con un
-    valor mayor o ``None`` se usa el historial ``hist_glifos`` limitado a los
-    últimos ``window`` elementos por nodo.
+    Si ``last_only`` es ``True`` cuenta solo el último glifo de cada nodo. En
+    caso contrario se usa el historial ``hist_glifos`` limitado a los últimos
+    ``window`` elementos por nodo (o a todo el deque si ``window`` es ``None``).
     """
-    if window == 1:
-        return _count_last_glifos(G)
+    if last_only:
+        counts: Counter[str] = Counter()
+        for _, nd in G.nodes(data=True):
+            g = last_glifo(nd)
+            if g:
+                counts[g] += 1
+        return counts
+
     counts: Counter[str] = Counter()
     for _, nd in G.nodes(data=True):
         hist = nd.get("hist_glifos")

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -98,7 +98,7 @@ def carga_glifica(G, window: int | None = None) -> dict:
     - window: si se indica, cuenta solo los últimos `window` eventos por nodo; si no, usa el maxlen del deque.
     Retorna un dict con proporciones por glifo y agregados útiles.
     """
-    total = count_glyphs(G, window=window)
+    total = count_glyphs(G, window=window, last_only=(window == 1))
     count = sum(total.values())
     if count == 0:
         return {"_count": 0}

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -198,7 +198,7 @@ def push_sigma_snapshot(G, t: float | None = None) -> None:
     hist.setdefault(key, []).append(sv)
 
     # Conteo de glifos por paso (útil para rosa glífica)
-    counts = count_glyphs(G, window=1)
+    counts = count_glyphs(G, last_only=True)
     hist.setdefault("sigma_counts", []).append({"t": sv["t"], **counts})
 
     # Trayectoria por nodo (opcional)

--- a/tests/test_count_glyphs.py
+++ b/tests/test_count_glyphs.py
@@ -1,0 +1,16 @@
+import networkx as nx
+from collections import deque, Counter
+
+from tnfr.helpers import count_glyphs
+from tnfr.constants import ALIAS_EPI_KIND
+
+def test_count_glyphs_last_only_and_window():
+    G = nx.Graph()
+    G.add_node(0, hist_glifos=deque(["A", "B"]))
+    G.add_node(1, **{ALIAS_EPI_KIND[0]: "C"})
+
+    last = count_glyphs(G, last_only=True)
+    assert last == Counter({"B": 1, "C": 1})
+
+    recent = count_glyphs(G, window=2)
+    assert recent == Counter({"A": 1, "B": 1})


### PR DESCRIPTION
## Summary
- add `last_only` parameter to `count_glyphs`
- update glyph counting calls to use new flag
- test glyph counting for both history window and last-only modes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b52816aa0c832186a10826418e34b1