### PR TITLE
Refactor ΔNFR caching with LRU and add tests

### DIFF
--- a/tests/test_dnfr_cache.py
+++ b/tests/test_dnfr_cache.py
@@ -1,0 +1,38 @@
+import pytest
+import networkx as nx
+
+from tnfr.dynamics import default_compute_delta_nfr, _cached_nodes_and_A
+from tnfr.constants import ALIAS_THETA, ALIAS_EPI, ALIAS_VF, ALIAS_DNFR
+from tnfr.helpers import get_attr
+
+
+def _setup_graph():
+    G = nx.path_graph(3)
+    for n in G.nodes:
+        G.nodes[n][ALIAS_THETA[0]] = 0.1 * (n + 1)
+        G.nodes[n][ALIAS_EPI[0]] = 0.2 * (n + 1)
+        G.nodes[n][ALIAS_VF[0]] = 0.3 * (n + 1)
+    G.graph["DNFR_WEIGHTS"] = {"phase": 1.0, "epi": 0.0, "vf": 0.0, "topo": 0.0}
+    return G
+
+
+@pytest.mark.parametrize("vectorized", [False, True])
+def test_cache_invalidated_on_graph_change(vectorized):
+    if vectorized:
+        pytest.importorskip("numpy")
+
+    G = _setup_graph()
+    G.graph["vectorized_dnfr"] = vectorized
+    default_compute_delta_nfr(G)
+    assert _cached_nodes_and_A.cache_info().currsize == 1
+    before = [get_attr(G.nodes[n], ALIAS_DNFR, 0.0) for n in G.nodes]
+
+    G.add_edge(2, 3)  # Cambia número de nodos y aristas
+    G.graph["vectorized_dnfr"] = vectorized
+    default_compute_delta_nfr(G)
+    assert _cached_nodes_and_A.cache_info().currsize == 1
+    after = [get_attr(G.nodes[n], ALIAS_DNFR, 0.0) for n in G.nodes]
+
+    assert len(after) == 4
+    assert before[2] != pytest.approx(after[2])
+


### PR DESCRIPTION
## Summary
- Replace manual graph cache with `lru_cache` based on `frozenset(G.edges)`
- Reset cache when node or edge counts change
- Test cache invalidation for vectorized and non-vectorized paths

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b52a5a1f3083218db26d190b54d5f2