### PR TITLE
feat: bound history with configurable maxlen

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ pip install tnfr
 
 ---
 
+## History configuration
+
+Recorded series are stored under `G.graph['history']`. Set `HISTORY_MAXLEN` in
+the graph (or override the default) to keep only the most recent entries. When
+the limit is positive the library uses bounded `deque` objects and removes the
+least populated series when the number of history keys grows beyond the limit.
+
+---
+
 ## Trained GPT
 
 https://chatgpt.com/g/g-67abc78885a88191b2d67f94fd60dc97-tnfr-teoria-de-la-naturaleza-fractal-resonante

--- a/src/tnfr/constants/core.py
+++ b/src/tnfr/constants/core.py
@@ -101,6 +101,7 @@ class CoreDefaults:
     CALLBACKS_STRICT: bool = False
     VALIDATORS_STRICT: bool = False
     PROGRAM_TRACE_MAXLEN: int = 50
+    HISTORY_MAXLEN: int = 0
 
 
 @dataclass(frozen=True)

--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -55,7 +55,8 @@ from .gamma import eval_gamma
 from .helpers import (
      clamp, clamp01, list_mean, angle_diff,
      get_attr, set_attr, get_attr_str, set_attr_str, media_vecinal, fase_media,
-     invoke_callbacks, reciente_glifo, set_vf, set_dnfr, compute_Si, normalize_weights
+     invoke_callbacks, reciente_glifo, set_vf, set_dnfr, compute_Si, normalize_weights,
+     ensure_history,
 )
 
 # Cacheo centralizado de nodos y matriz de adyacencia
@@ -826,8 +827,8 @@ def parametric_glyph_selector(G, n) -> str:
 
 def step(G, *, dt: float | None = None, use_Si: bool = True, apply_glyphs: bool = True) -> None:
     # Contexto inicial
-    _hist0 = G.graph.setdefault("history", {"C_steps": []})
-    step_idx = len(_hist0.get("C_steps", []))
+    _hist0 = ensure_history(G)
+    step_idx = len(_hist0.setdefault("C_steps", []))
     invoke_callbacks(G, "before_step", {"step": step_idx, "dt": dt, "use_Si": use_Si, "apply_glyphs": apply_glyphs})
 
     # 1) ΔNFR (campo)
@@ -980,7 +981,7 @@ def _update_sigma(G, hist) -> None:
 
 
 def _update_history(G) -> None:
-    hist = G.graph.setdefault("history", {})
+    hist = ensure_history(G)
     for k in (
         "C_steps", "stable_frac", "phase_sync", "glyph_load_estab", "glyph_load_disr",
         "Si_mean", "Si_hi_frac", "Si_lo_frac", "delta_Si", "B"

--- a/tests/test_history_maxlen.py
+++ b/tests/test_history_maxlen.py
@@ -1,0 +1,26 @@
+from collections import deque
+
+from tnfr.constants import attach_defaults
+from tnfr.helpers import ensure_history
+
+
+def test_history_maxlen_and_cleanup(graph_canon):
+    G = graph_canon()
+    G.add_node(0)
+    attach_defaults(G)
+    G.graph["HISTORY_MAXLEN"] = 2
+
+    hist = ensure_history(G)
+    hist.setdefault("a", []).append(1)
+    hist.setdefault("b", []).append(2)
+    hist.setdefault("c", []).append(3)
+
+    # trigger cleanup
+    ensure_history(G)
+    assert len(hist) == 2
+
+    series = hist.setdefault("series", [])
+    series.extend([1, 2, 3])
+    assert isinstance(series, deque)
+    assert series.maxlen == 2
+    assert list(series) == [2, 3]


### PR DESCRIPTION
## Summary
- ensure history uses bounded deques and drops least used keys
- expose HISTORY_MAXLEN default and apply in dynamics
- document history configuration

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b52d3a277483219d6e0cf5a41d129a