### PR TITLE
Raise KeyError for unknown defaults in get_param

### DIFF
--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -85,7 +85,10 @@ def get_param(G, key: str):
                 stacklevel=2,
             )
             return G.graph[alias]
-    return DEFAULTS[key]
+    value = DEFAULTS.get(key)
+    if value is None:
+        raise KeyError(f"Parámetro desconocido: '{key}'")
+    return value
 
 
 # Alias exportados por conveniencia (evita imports circulares)


### PR DESCRIPTION
## Summary
- handle missing default parameters in `get_param`
- raise a descriptive KeyError when an unknown parameter is requested

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b55de39634832181aa0c99b7ef380b