### PR TITLE
refactor: simplify reciente_glifo lookup

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -373,11 +373,8 @@ def reciente_glifo(nd: Dict[str, Any], glifo: str, ventana: int) -> bool:
     gl = str(glifo)
     if ventana < 0:
         raise ValueError("ventana debe ser >= 0")
-    if hist:
-        limite = min(len(hist), ventana)
-        for i in range(1, limite + 1):
-            if hist[-i] == gl:
-                return True
+    if hist and ventana > 0 and gl in list(hist)[-ventana:]:
+        return True
     # fallback al glifo dominante actual
     return get_attr_str(nd, ALIAS_EPI_KIND, "") == gl
 


### PR DESCRIPTION
## Summary
- streamline `reciente_glifo` by replacing manual loop with membership check on tail slice
- retain fallback to `ALIAS_EPI_KIND`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b560a6520883218f25f2e203b47d96