### PR TITLE
Use networkx type check for graphs

### DIFF
--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -3,6 +3,8 @@ from typing import Dict, List
 import math
 from collections import Counter
 
+import networkx as nx
+
 from .constants import ALIAS_SI, ALIAS_EPI, SIGMA
 from .helpers import (
     get_attr,
@@ -150,7 +152,7 @@ def sigma_vector_global(G, weight_mode: str | None = None) -> Dict[str, float]:
 
     Si no hay datos suficientes retorna el vector nulo.
     """
-    if not hasattr(G, "nodes"):
+    if not isinstance(G, nx.Graph):
         # Compatibilidad retro: si se pasa una distribución directamente,
         # derivamos a la variante específica.
         return sigma_vector(G)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- import networkx in sigma module for explicit graph type checks
- replace hasattr-based graph detection with isinstance against nx.Graph in sigma_vector_global

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5654035048321b4994266e8dbef27