### PR TITLE
refactor: remove internal deque import

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -36,8 +36,6 @@ from . import __version__
 
 
 def _parse_tokens(obj: Any) -> List[Any]:
-    from collections import deque
-
     out: List[Any] = []
     queue = deque(obj if isinstance(obj, list) else [obj])
     pos = 0


### PR DESCRIPTION
## Summary
- remove redundant deque import inside `_parse_tokens`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5665d98a08321ae7c36b5c6aea6c1