### PR TITLE
refactor: centralize ensure_parent helper

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -5,7 +5,6 @@ import logging
 import sys
 from typing import Any, Dict, List, Optional, Callable
 from pathlib import Path
-import os
 from collections import deque
 
 import networkx as nx
@@ -30,7 +29,7 @@ from .gamma import GAMMA_REGISTRY
 from .scenarios import build_graph
 from .presets import get_preset
 from .config import apply_config
-from .helpers import read_structured_file, list_mean
+from .helpers import read_structured_file, list_mean, ensure_parent
 from .observers import attach_standard_observer
 from . import __version__
 
@@ -82,13 +81,6 @@ def _save_json(path: str, data: Any) -> None:
 
     with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=2, default=_default)
-
-
-def ensure_parent(path: str) -> None:
-    """Create parent directory of ``path`` if needed."""
-    dir_name = os.path.dirname(path)
-    if dir_name:
-        os.makedirs(dir_name, exist_ok=True)
 
 
 def _str2bool(s: str) -> bool:
@@ -315,9 +307,7 @@ def cmd_metrics(args: argparse.Namespace) -> int:
         "glifogram": {k: v[:10] for k, v in glifo.items()},
     }
     if args.save:
-        dir_name = os.path.dirname(args.save)
-        if dir_name:
-            os.makedirs(dir_name, exist_ok=True)
+        ensure_parent(args.save)
         _save_json(args.save, out)
     else:
         logger.info("%s", json.dumps(out, ensure_ascii=False, indent=2))

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -29,6 +29,7 @@ T = TypeVar("T")
 
 __all__ = [
     "read_structured_file",
+    "ensure_parent",
     "clamp",
     "clamp_abs",
     "clamp01",
@@ -94,6 +95,11 @@ def read_structured_file(path: Path) -> Any:
     except Exception as e:
         formato = "YAML" if parser is _parse_yaml else "JSON"
         raise ValueError(f"Error al parsear {formato} en {path}: {e}") from e
+
+
+def ensure_parent(path: str | Path) -> None:
+    """Crea el directorio padre de ``path`` si hace falta."""
+    Path(path).parent.mkdir(parents=True, exist_ok=True)
 
 # -------------------------
 # Utilidades numéricas

--- a/src/tnfr/metrics/export.py
+++ b/src/tnfr/metrics/export.py
@@ -2,10 +2,9 @@ from __future__ import annotations
 
 import csv
 import json
-import os
 from typing import Dict, List
 
-from ..helpers import ensure_history
+from ..helpers import ensure_history, ensure_parent
 from ..sense import GLYPHS_CANONICAL
 from .core import glifogram_series
 
@@ -21,7 +20,7 @@ def _write_csv(path, headers, rows):
 def export_history(G, base_path: str, fmt: str = "csv") -> None:
     """Vuelca glifograma y traza σ(t) a archivos CSV o JSON compactos."""
     hist = ensure_history(G)
-    os.makedirs(os.path.dirname(base_path) or ".", exist_ok=True)
+    ensure_parent(base_path)
     glifo = glifogram_series(G)
     sigma_mag = hist.get("sense_sigma_mag", [])
     sigma = {


### PR DESCRIPTION
## Summary
- centralize ensure_parent in helpers module
- use ensure_parent to create output directories in CLI and metrics export

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b567b4dd68832189e832b91d3e5fb5