### PR TITLE
refactor: centralize coherence calculation

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -56,7 +56,7 @@ from .helpers import (
      clamp, clamp01, list_mean, angle_diff,
      get_attr, set_attr, get_attr_str, set_attr_str, media_vecinal, fase_media,
      invoke_callbacks, reciente_glifo, set_vf, set_dnfr, compute_Si, normalize_weights,
-     ensure_history,
+     ensure_history, compute_coherence,
 )
 
 # Cacheo centralizado de nodos y matriz de adyacencia
@@ -945,9 +945,7 @@ def run(G, steps: int, *, dt: float | None = None, use_Si: bool = True, apply_gl
 
 def _update_coherence(G, hist) -> None:
     """Actualizar la coherencia global y su media móvil."""
-    dnfr_mean = list_mean(abs(get_attr(G.nodes[n], ALIAS_DNFR, 0.0)) for n in G.nodes())
-    dEPI_mean = list_mean(abs(get_attr(G.nodes[n], ALIAS_dEPI, 0.0)) for n in G.nodes())
-    C = 1.0 / (1.0 + dnfr_mean + dEPI_mean)
+    C = compute_coherence(G)
     hist["C_steps"].append(C)
 
     wbar_w = int(G.graph.get("WBAR_WINDOW", METRIC_DEFAULTS.get("WBAR_WINDOW", 25)))

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -23,7 +23,7 @@ try:
 except ImportError:  # pragma: no cover
     nx = None  # type: ignore
 
-from .constants import DEFAULTS, ALIAS_VF, ALIAS_THETA, ALIAS_DNFR, ALIAS_SI, ALIAS_EPI_KIND
+from .constants import DEFAULTS, ALIAS_VF, ALIAS_THETA, ALIAS_DNFR, ALIAS_dEPI, ALIAS_SI, ALIAS_EPI_KIND
 
 T = TypeVar("T")
 
@@ -55,6 +55,7 @@ __all__ = [
     "count_glyphs",
     "register_callback",
     "invoke_callbacks",
+    "compute_coherence",
     "compute_Si",
 ]
 
@@ -325,6 +326,20 @@ def set_vf(G, n, value: float) -> None:
 def set_dnfr(G, n, value: float) -> None:
     """Asigna ``ΔNFR`` y actualiza el máximo global."""
     set_attr_with_max(G, n, ALIAS_DNFR, value, cache="_dnfrmax")
+
+# -------------------------
+# Coherencia global
+# -------------------------
+
+def compute_coherence(G) -> float:
+    """Calcula la coherencia global C(t) a partir de ΔNFR y dEPI."""
+    dnfr_mean = list_mean(
+        abs(get_attr(G.nodes[n], ALIAS_DNFR, 0.0)) for n in G.nodes()
+    )
+    depi_mean = list_mean(
+        abs(get_attr(G.nodes[n], ALIAS_dEPI, 0.0)) for n in G.nodes()
+    )
+    return 1.0 / (1.0 + dnfr_mean + depi_mean)
 
 # -------------------------
 # Estadísticos vecinales

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -7,14 +7,14 @@ from __future__ import annotations
 import math
 import statistics as st
 
-from .constants import ALIAS_DNFR, ALIAS_THETA, ALIAS_dEPI, METRIC_DEFAULTS
+from .constants import ALIAS_THETA, METRIC_DEFAULTS
 from .helpers import (
     get_attr,
-    list_mean,
     register_callback,
     angle_diff,
     ensure_history,
     count_glyphs,
+    compute_coherence,
 )
 from .constants_glifos import ESTABILIZADORES, DISRUPTIVOS
 from .gamma import kuramoto_R_psi
@@ -50,9 +50,7 @@ def attach_standard_observer(G):
 
 def coherencia_global(G) -> float:
     """Proxy de C(t): alta cuando |ΔNFR| y |dEPI_dt| son pequeños."""
-    dnfr = list_mean(abs(get_attr(G.nodes[n], ALIAS_DNFR, 0.0)) for n in G.nodes())
-    dEPI = list_mean(abs(get_attr(G.nodes[n], ALIAS_dEPI, 0.0)) for n in G.nodes())
-    return 1.0 / (1.0 + dnfr + dEPI)
+    return compute_coherence(G)
 
 
 def _phase_sums(G) -> tuple[float, float, list[float]]:


### PR DESCRIPTION
## Summary
- extract shared compute_coherence helper for calculating global coherence
- use compute_coherence in observers and dynamics modules

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b56a1ceed8832182c888d7bf392492