### PR TITLE
chore: remove debug comment from ontosim example

### DIFF
--- a/examples/ontosim_example.py
+++ b/examples/ontosim_example.py
@@ -13,7 +13,6 @@ def main() -> None:
     G = nx.erdos_renyi_graph(30, 0.15)
     preparar_red(G)
     run(G, 100)
-    # print("C(t) muestras:", G.graph["history"]["C_steps"][-5:])  # usado solo para pruebas
 
 
 if __name__ == "__main__":  # pragma: no cover - ejemplo manual


### PR DESCRIPTION
## Summary
- remove leftover commented-out debug print

## Testing
- `PYTHONPATH=src python examples/ontosim_example.py`
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b56ec0373083218fc1cbc6cce3c20b