### PR TITLE
refactor: simplify glyph execution

### DIFF
--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -393,12 +393,8 @@ def aplicar_glifo_obj(node: NodoProtocol, glifo: Glyph | str, *, window: Optiona
         raise ValueError(f"glifo sin operador: {g}")
     if window is None:
         window = int(get_param(node, "GLYPH_HYSTERESIS_WINDOW"))
-    try:
-        op(node)
-    except Exception:
-        raise
-    else:
-        node.push_glifo(g.value, window)
+    op(node)
+    node.push_glifo(g.value, window)
 
 
 def aplicar_glifo(G, n, glifo: Glyph | str, *, window: Optional[int] = None) -> None:


### PR DESCRIPTION
## Summary
- remove redundant try/except around glyph operator call
- record glyph history only on successful operator execution

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5729309508321923ff21c160ab5f9