### PR TITLE
Refactor glyph counting window logic

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -491,9 +491,7 @@ def count_glyphs(
             continue
         if window is not None and window > 0:
             window_int = int(window)
-            seq = reversed(
-                list(islice(hist, max(0, len(hist) - window_int), len(hist)))
-            )
+            seq = islice(reversed(hist), window_int)
         else:
             seq = hist
         counts.update(seq)


### PR DESCRIPTION
## Summary
- simplify `count_glyphs` window handling to avoid materializing lists
- iterate only necessary elements with `islice(reversed(hist), window_int)`

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b578bea56083219e9c5d96ff97bc76