### PR TITLE
refactor: compute EPI once per node

### DIFF
--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -98,11 +98,11 @@ def _update_latency_index(G, hist, n_total, n_latent, t):
 
 def _update_epi_support(G, hist, t, thr):
     """Calcula soporte y norma de la EPI."""
-    vals = [
-        abs(get_attr(G.nodes[n], ALIAS_EPI, 0.0))
-        for n in G.nodes()
-        if abs(get_attr(G.nodes[n], ALIAS_EPI, 0.0)) >= thr
-    ]
+    vals = []
+    for n in G.nodes():
+        epi_val = abs(get_attr(G.nodes[n], ALIAS_EPI, 0.0))
+        if epi_val >= thr:
+            vals.append(epi_val)
     epi_norm = list_mean(vals, 0.0)
     size = len(vals)
     hist.setdefault("EPI_support", []).append(


### PR DESCRIPTION
## Summary
- avoid redundant attribute fetches by storing EPI value per node

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5797fe460832199c3837ab23a53ba