### PR TITLE
Use tuple-based checksum for node mapping

### DIFF
--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -5,6 +5,7 @@ import math
 import random
 import hashlib
 import heapq
+import pickle
 import networkx as nx
 from networkx.algorithms import community as nx_comm
 from functools import lru_cache
@@ -45,7 +46,7 @@ def _ensure_node_offset_map(G) -> Dict[Any, int]:
     """
 
     nodes = list(G.nodes())
-    checksum = hashlib.blake2b(",".join(map(str, nodes)).encode(), digest_size=16).hexdigest()
+    checksum = hashlib.blake2b(pickle.dumps(tuple(nodes)), digest_size=16).hexdigest()
     mapping = G.graph.get("_node_offset_map")
     if mapping is None or G.graph.get("_node_offset_checksum") != checksum:
         if bool(G.graph.get("SORT_NODES", False)):


### PR DESCRIPTION
## Summary
- compute `_node_offset_map` checksum from pickled node tuples for immutability
- add `pickle` import

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b57ae1f6e08321885a3a87c9b531b1