### PR TITLE
Use deep copy when injecting defaults

### DIFF
--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from collections import ChainMap
 from typing import Any, Dict
+import copy
 import warnings
 
 from .core import CORE_DEFAULTS, REMESH_DEFAULTS
@@ -58,7 +59,7 @@ def inject_defaults(
     G.graph.setdefault("_tnfr_defaults_attached", False)
     for k, v in defaults.items():
         if override or k not in G.graph:
-            G.graph[k] = v
+            G.graph[k] = copy.deepcopy(v)
     G.graph["_tnfr_defaults_attached"] = True
     try:  # local import para evitar dependencia circular
         from ..operators import _ensure_node_offset_map


### PR DESCRIPTION
## Summary
- Deep copy constants when injecting defaults into `G.graph`
- Import `copy` module for deep copy support

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b588dc38188321853d25641275a0ec