### PR TITLE
refactor: expose CLI JSON serializer globally

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -73,12 +73,15 @@ TOKEN_MAP: Dict[str, Callable[[Any], Any]] = {
 }
 
 
-def _save_json(path: str, data: Any) -> None:
-    def _default(obj):
-        if isinstance(obj, deque):
-            return list(obj)
-        raise TypeError(f"Object of type {obj.__class__.__name__} is not JSON serializable")
+def _default(obj: Any) -> Any:
+    if isinstance(obj, deque):
+        return list(obj)
+    raise TypeError(
+        f"Object of type {obj.__class__.__name__} is not JSON serializable"
+    )
 
+
+def _save_json(path: str, data: Any) -> None:
     with open(path, "w", encoding="utf-8") as f:
         json.dump(data, f, ensure_ascii=False, indent=2, default=_default)
 


### PR DESCRIPTION
## Summary
- move `_default` JSON helper to module scope
- pass global `_default` serializer to `json.dump`

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b58eacca908321af3cd080213b2abb