### PR TITLE
feat: introduce per-step node sampling for UM operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ the graph (or override the default) to keep only the most recent entries. When
 the limit is positive the library uses bounded `deque` objects and removes the
 least populated series when the number of history keys grows beyond the limit.
 
+### Random node sampling
+
+To reduce costly comparisons the engine stores a per‑step random subset of
+node ids under `G.graph['_node_sample']`. Operators may use this to avoid
+scanning the whole network. Sampling is skipped automatically when the graph
+has fewer than **50 nodes**, in which case all nodes are included.
+
 ---
 
 ## Trained GPT

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -214,6 +214,11 @@ def _op_UM(node: NodoProtocol) -> None:  # UM — Acoplamiento
     * ``"proximity"``: selecciona los nodos más cercanos en fase.
     * ``"sample"``: toma una muestra determinista.
 
+    Desde ``dynamics.step`` se mantiene en ``G.graph['_node_sample']`` una
+    muestra aleatoria renovada en cada paso. Cuando el grafo es pequeño
+    (``<50`` nodos) la muestra contiene todos los nodos y el muestreo se
+    desactiva.
+
     Esto preserva la lógica de acoplamiento sin revisar todos los nodos.
     """
 
@@ -229,8 +234,15 @@ def _op_UM(node: NodoProtocol) -> None:  # UM — Acoplamiento
         epi_i = node.EPI
         si_i = node.Si
 
+        sample_ids = node.graph.get("_node_sample")
+        if sample_ids is not None and hasattr(node, "G"):
+            from .node import NodoNX
+            iter_nodes = (NodoNX(node.G, j) for j in sample_ids)
+        else:
+            iter_nodes = node.all_nodes()
+
         candidates = []
-        for j in node.all_nodes():
+        for j in iter_nodes:
             same = (j is node) or (getattr(node, "n", None) == getattr(j, "n", None))
             if same or node.has_edge(j):
                 continue

--- a/tests/test_node_sample.py
+++ b/tests/test_node_sample.py
@@ -1,0 +1,29 @@
+from tnfr.dynamics import step
+from tnfr.constants import attach_defaults
+import networkx as nx
+
+
+def _build_graph(n):
+    G = nx.Graph()
+    attach_defaults(G)
+    for i in range(n):
+        G.add_node(i, **{"θ": 0.0, "EPI": 0.0})
+    return G
+
+
+def test_node_sample_large_graph():
+    G = _build_graph(80)
+    G.graph["UM_CANDIDATE_COUNT"] = 10
+    step(G, use_Si=False, apply_glyphs=False)
+    sample = G.graph.get("_node_sample")
+    assert isinstance(sample, list)
+    assert len(sample) == 10
+    assert set(sample).issubset(set(G.nodes()))
+
+
+def test_node_sample_small_graph():
+    G = _build_graph(20)
+    G.graph["UM_CANDIDATE_COUNT"] = 5
+    step(G, use_Si=False, apply_glyphs=False)
+    sample = G.graph.get("_node_sample")
+    assert len(sample) == len(G.nodes())


### PR DESCRIPTION
## Summary
- maintain a per-step random node sample in `G.graph['_node_sample']`
- use sampled nodes in UM coupling operator to avoid full network scans
- document node sampling and add tests covering large and small graphs

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5946e84648321b5ed7bde84110df4