### PR TITLE
refactor: drop coherencia_global proxy

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -13,7 +13,8 @@ __version__ = "4.5.2"
 # Re-exports de la API pública
 from .dynamics import step, run, set_delta_nfr_hook, validate_canon
 from .ontosim import preparar_red
-from .observers import attach_standard_observer, coherencia_global, orden_kuramoto
+from .observers import attach_standard_observer, orden_kuramoto
+from .helpers import compute_coherence
 from .gamma import GAMMA_REGISTRY, eval_gamma, kuramoto_R_psi
 from .grammar import enforce_canonical_grammar, on_applied_glifo, apply_glyph_with_grammar
 from .sense import (
@@ -61,7 +62,7 @@ __all__ = [
     "preparar_red",
     "step", "run", "set_delta_nfr_hook", "validate_canon",
 
-    "attach_standard_observer", "coherencia_global", "orden_kuramoto",
+    "attach_standard_observer", "orden_kuramoto", "compute_coherence",
     "GAMMA_REGISTRY", "eval_gamma", "kuramoto_R_psi",
     "enforce_canonical_grammar", "on_applied_glifo",
     "apply_glyph_with_grammar",

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -48,10 +48,6 @@ def attach_standard_observer(G):
     G.graph.setdefault("_STD_OBSERVER", "attached")
     return G
 
-def coherencia_global(G) -> float:
-    """Proxy de C(t): alta cuando |ΔNFR| y |dEPI_dt| son pequeños."""
-    return compute_coherence(G)
-
 
 def _phase_sums(G) -> tuple[float, float, list[float]]:
     """Devuelve sumX, sumY y la lista de fases nodales."""
@@ -124,7 +120,7 @@ def wbar(G, window: int | None = None) -> float:
     cs = hist.get("C_steps", [])
     if not cs:
         # fallback: coherencia instantánea
-        return coherencia_global(G)
+        return compute_coherence(G)
     if window is None:
         window = int(G.graph.get("WBAR_WINDOW", METRIC_DEFAULTS.get("WBAR_WINDOW", 25)))
     w = min(len(cs), max(1, int(window)))


### PR DESCRIPTION
## Summary
- remove `coherencia_global` helper and use `compute_coherence` directly
- export `compute_coherence` from top-level package

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b59bab10d883219eab1ae9a64f1a2c