### PR TITLE
Refactor compute_coherence to single traversal

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -332,12 +332,19 @@ def set_dnfr(G, n, value: float) -> None:
 
 def compute_coherence(G) -> float:
     """Calcula la coherencia global C(t) a partir de ΔNFR y dEPI."""
-    dnfr_mean = list_mean(
-        abs(get_attr(G.nodes[n], ALIAS_DNFR, 0.0)) for n in G.nodes()
-    )
-    depi_mean = list_mean(
-        abs(get_attr(G.nodes[n], ALIAS_dEPI, 0.0)) for n in G.nodes()
-    )
+    dnfr_sum = 0.0
+    depi_sum = 0.0
+    count = 0
+    for n in G.nodes():
+        nd = G.nodes[n]
+        dnfr_sum += abs(get_attr(nd, ALIAS_DNFR, 0.0))
+        depi_sum += abs(get_attr(nd, ALIAS_dEPI, 0.0))
+        count += 1
+    if count:
+        dnfr_mean = dnfr_sum / count
+        depi_mean = depi_sum / count
+    else:
+        dnfr_mean = depi_mean = 0.0
     return 1.0 / (1.0 + dnfr_mean + depi_mean)
 
 # -------------------------


### PR DESCRIPTION
## Summary
- Refactor `compute_coherence` to accumulate ΔNFR and dEPI in a single loop over graph nodes
- Compute mean values after traversal to avoid redundant passes

## Testing
- `PYTHONPATH=src pytest tests/test_metrics.py -q`
- `PYTHONPATH=src pytest tests/test_observers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5a0d565f083219b5bb271a12af01f