### PR TITLE
refactor: lazy import numpy for dnfr vectorization

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -21,14 +21,36 @@ import networkx as nx
 
 logger = logging.getLogger(__name__)
 
-try:  # Optional dependency
-    import numpy as np  # type: ignore
-except ImportError:  # pragma: no cover - handled gracefully
-    logger.warning(
-        "Fallo al importar numpy, se continuará con el modo no vectorizado",
-        exc_info=True,
-    )
-    np = None  # type: ignore
+# ``numpy`` is an optional dependency.  It is loaded lazily to avoid emitting
+# warnings when the vectorized path is not used.
+np: Any | None = None
+
+def _ensure_numpy(*, warn: bool = False) -> bool:
+    """Load ``numpy`` on demand.
+
+    Parameters
+    ----------
+    warn:
+        If ``True`` the failure to import ``numpy`` is logged as a warning,
+        otherwise a debug message is emitted. Returns ``True`` if ``numpy``
+        was imported successfully.
+    """
+
+    global np
+    if np is not None:  # pragma: no cover - already loaded
+        return True
+    try:  # Optional dependency
+        import numpy as _np  # type: ignore
+    except ImportError:  # pragma: no cover - handled gracefully
+        log = logger.warning if warn else logger.debug
+        log(
+            "Fallo al importar numpy, se continuará con el modo no vectorizado",
+            exc_info=True,
+        )
+        np = None
+        return False
+    np = _np
+    return True
 
 from .observers import sincronía_fase, carga_glifica, orden_kuramoto
 from .sense import sigma_vector
@@ -164,7 +186,7 @@ def _prepare_dnfr_data(G, *, cache_size: int | None = 1) -> dict:
     if weights is None:
         weights = _configure_dnfr_weights(G)
 
-    use_numpy = np is not None and G.graph.get("vectorized_dnfr")
+    use_numpy = _ensure_numpy() and G.graph.get("vectorized_dnfr")
 
     # Cacheo de la lista de nodos y la matriz de adyacencia
     nodes, A = _cached_nodes_and_A(G, cache_size=cache_size)
@@ -199,7 +221,7 @@ def _prepare_dnfr_data(G, *, cache_size: int | None = 1) -> dict:
 
 def _compute_dnfr_numpy(G, data) -> None:
     """Estrategia vectorizada usando ``numpy``."""
-    if np is None:  # pragma: no cover - check at runtime
+    if not _ensure_numpy(warn=True):  # pragma: no cover - check at runtime
         raise RuntimeError("numpy no disponible para la versión vectorizada")
     nodes = data["nodes"]
     if not nodes:


### PR DESCRIPTION
## Summary
- load numpy lazily via `_ensure_numpy` helper
- warn about missing numpy only when vectorized path executes

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5a17e18088321bffe3ca2abb4016b