### PR TITLE
Handle duplicate callbacks in register_callback

### DIFF
--- a/tests/test_register_callback.py
+++ b/tests/test_register_callback.py
@@ -1,0 +1,23 @@
+from tnfr.helpers import register_callback
+
+
+def test_register_callback_replaces_existing(graph_canon):
+    G = graph_canon()
+
+    def cb1(G, ctx):
+        pass
+
+    def cb2(G, ctx):
+        pass
+
+    # initial registration
+    register_callback(G, event="before_step", func=cb1, name="cb")
+    assert G.graph["callbacks"]["before_step"] == [("cb", cb1)]
+
+    # same name should replace existing
+    register_callback(G, event="before_step", func=cb2, name="cb")
+    assert G.graph["callbacks"]["before_step"] == [("cb", cb2)]
+
+    # same function with different name should also replace existing
+    register_callback(G, event="before_step", func=cb2, name="other")
+    assert G.graph["callbacks"]["before_step"] == [("other", cb2)]


### PR DESCRIPTION
## Summary
- Avoid duplicate callback registration by replacing existing callbacks with the same name or function
- Add regression test for callback replacement semantics

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5a34022a08321acf00f995355f4af