### PR TITLE
Use default parameter when computing selector norms

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -770,7 +770,7 @@ def default_glyph_selector(G, n) -> str:
 
     norms = G.graph.get("_sel_norms")
     if norms is not None:
-        dnfr_max = float(norms.get("dnfr_max", 1.0))
+        dnfr_max = float(norms.get("dnfr_max", 1.0)) or 1.0
     else:
         dnfr_max = 0.0
         for _, nd2 in G.nodes(data=True):
@@ -821,8 +821,8 @@ def parametric_glyph_selector(G, n) -> str:
 
     # Normalizadores por paso
     norms = G.graph.get("_sel_norms") or _norms_para_selector(G)
-    dnfr_max = float(norms.get("dnfr_max", 1.0))
-    acc_max  = float(norms.get("accel_max", 1.0))
+    dnfr_max = float(norms.get("dnfr_max", 1.0)) or 1.0
+    acc_max  = float(norms.get("accel_max", 1.0)) or 1.0
 
     # Lecturas nodales
     Si = clamp01(get_attr(nd, ALIAS_SI, 0.5))

--- a/src/tnfr/selector.py
+++ b/src/tnfr/selector.py
@@ -86,15 +86,14 @@ def _selector_thresholds(G: nx.Graph) -> dict:
 
 def _norms_para_selector(G: nx.Graph) -> dict:
     """Calcula y guarda en ``G.graph`` los máximos para normalizar |ΔNFR| y |d2EPI/dt2|."""
-    dnfr_max = 0.0
-    accel_max = 0.0
-    for _, nd in G.nodes(data=True):
-        dnfr_max = max(dnfr_max, abs(get_attr(nd, ALIAS_DNFR, 0.0)))
-        accel_max = max(accel_max, abs(get_attr(nd, ALIAS_D2EPI, 0.0)))
-    if dnfr_max <= 0:
-        dnfr_max = 1.0
-    if accel_max <= 0:
-        accel_max = 1.0
+    dnfr_max = max(
+        (abs(get_attr(nd, ALIAS_DNFR, 0.0)) for _, nd in G.nodes(data=True)),
+        default=0.0,
+    )
+    accel_max = max(
+        (abs(get_attr(nd, ALIAS_D2EPI, 0.0)) for _, nd in G.nodes(data=True)),
+        default=0.0,
+    )
     norms = {"dnfr_max": float(dnfr_max), "accel_max": float(accel_max)}
     G.graph["_sel_norms"] = norms
     return norms


### PR DESCRIPTION
## Summary
- simplify selector norm calculation by using generator-based `max` with defaults
- guard glyph selectors against zero denominators

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5a5cc1e1883218710c620a38a22c9