### PR TITLE
Load package version from metadata

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -8,7 +8,12 @@ Ecuación nodal:
     ∂EPI/∂t = νf · ΔNFR(t)
 """
 
-__version__ = "4.5.2"
+try:  # pragma: no cover
+    from importlib.metadata import version
+except ImportError:  # pragma: no cover
+    from importlib_metadata import version
+
+__version__ = version("tnfr")
 
 # Re-exports de la API pública
 from .dynamics import step, run, set_delta_nfr_hook, validate_canon


### PR DESCRIPTION
## Summary
- Use `importlib.metadata` to determine `tnfr`'s `__version__`
- Maintain `version` field in `pyproject.toml`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5a9a0b59883219b99cee7def974cc