### PR TITLE
refactor: centralize dnfr and accel norms

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -67,7 +67,7 @@ from .helpers import (
      clamp, clamp01, list_mean, angle_diff,
      get_attr, set_attr, get_attr_str, set_attr_str, media_vecinal, fase_media,
      invoke_callbacks, reciente_glifo, set_vf, set_dnfr, compute_Si, normalize_weights,
-     ensure_history, compute_coherence,
+     ensure_history, compute_coherence, compute_dnfr_accel_max,
 )
 from .selector import (
     _selector_thresholds,
@@ -758,14 +758,10 @@ def default_glyph_selector(G, n) -> str:
     dnfr_hi = thr["dnfr_hi"]
 
     norms = G.graph.get("_sel_norms")
-    if norms is not None:
-        dnfr_max = float(norms.get("dnfr_max", 1.0)) or 1.0
-    else:
-        dnfr_max = 0.0
-        for _, nd2 in G.nodes(data=True):
-            dnfr_max = max(dnfr_max, abs(get_attr(nd2, ALIAS_DNFR, 0.0)))
-        if dnfr_max <= 0:
-            dnfr_max = 1.0
+    if norms is None:
+        norms = compute_dnfr_accel_max(G)
+        G.graph["_sel_norms"] = norms
+    dnfr_max = float(norms.get("dnfr_max", 1.0)) or 1.0
 
     Si = clamp01(get_attr(nd, ALIAS_SI, 0.5))
     dnfr = abs(get_attr(nd, ALIAS_DNFR, 0.0)) / dnfr_max

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -18,7 +18,16 @@ except ImportError:  # pragma: no cover
 if TYPE_CHECKING:
     import networkx as nx
 
-from .constants import DEFAULTS, ALIAS_VF, ALIAS_THETA, ALIAS_DNFR, ALIAS_dEPI, ALIAS_SI, ALIAS_EPI_KIND
+from .constants import (
+    DEFAULTS,
+    ALIAS_VF,
+    ALIAS_THETA,
+    ALIAS_DNFR,
+    ALIAS_dEPI,
+    ALIAS_SI,
+    ALIAS_EPI_KIND,
+    ALIAS_D2EPI,
+)
 
 T = TypeVar("T")
 
@@ -50,6 +59,7 @@ __all__ = [
     "count_glyphs",
     "register_callback",
     "invoke_callbacks",
+    "compute_dnfr_accel_max",
     "compute_coherence",
     "compute_Si",
 ]
@@ -321,6 +331,25 @@ def set_vf(G, n, value: float) -> None:
 def set_dnfr(G, n, value: float) -> None:
     """Asigna ``ΔNFR`` y actualiza el máximo global."""
     set_attr_with_max(G, n, ALIAS_DNFR, value, cache="_dnfrmax")
+
+
+# -------------------------
+# Normalizadores de ΔNFR y aceleración
+# -------------------------
+
+def compute_dnfr_accel_max(G) -> dict:
+    """Calcula los máximos absolutos de |ΔNFR| y |d²EPI/dt²|.
+
+    Devuelve un diccionario con las claves ``dnfr_max`` y ``accel_max``.
+    Si el grafo no tiene nodos, ambos valores serán ``0.0``.
+    """
+
+    dnfr_max = 0.0
+    accel_max = 0.0
+    for _, nd in G.nodes(data=True):
+        dnfr_max = max(dnfr_max, abs(get_attr(nd, ALIAS_DNFR, 0.0)))
+        accel_max = max(accel_max, abs(get_attr(nd, ALIAS_D2EPI, 0.0)))
+    return {"dnfr_max": float(dnfr_max), "accel_max": float(accel_max)}
 
 # -------------------------
 # Coherencia global

--- a/src/tnfr/metrics/diagnosis.py
+++ b/src/tnfr/metrics/diagnosis.py
@@ -5,7 +5,13 @@ from statistics import fmean
 from typing import Dict
 
 from ..constants import ALIAS_EPI, ALIAS_VF, ALIAS_DNFR, ALIAS_SI, DIAGNOSIS, COHERENCE
-from ..helpers import register_callback, ensure_history, get_attr, clamp01
+from ..helpers import (
+    register_callback,
+    ensure_history,
+    get_attr,
+    clamp01,
+    compute_dnfr_accel_max,
+)
 from .coherence import local_phase_sync_weighted, _similarity_abs
 
 
@@ -54,8 +60,9 @@ def _diagnosis_step(G, ctx=None):
     hist = ensure_history(G)
     key = dcfg.get("history_key", "nodal_diag")
 
-    dnfr_vals = [abs(float(get_attr(G.nodes[v], ALIAS_DNFR, 0.0))) for v in G.nodes()]
-    dnfr_max = max(dnfr_vals) if dnfr_vals else 1.0
+    norms = compute_dnfr_accel_max(G)
+    G.graph["_sel_norms"] = norms
+    dnfr_max = float(norms.get("dnfr_max", 1.0)) or 1.0
     epi_vals = [float(get_attr(G.nodes[v], ALIAS_EPI, 0.0)) for v in G.nodes()]
     epi_min, epi_max = (min(epi_vals) if epi_vals else 0.0), (max(epi_vals) if epi_vals else 1.0)
 

--- a/src/tnfr/selector.py
+++ b/src/tnfr/selector.py
@@ -6,7 +6,7 @@ from typing import Any, Dict
 import networkx as nx
 
 from .constants import DEFAULTS, ALIAS_DNFR, ALIAS_D2EPI
-from .helpers import clamp01, get_attr
+from .helpers import clamp01, get_attr, compute_dnfr_accel_max
 
 
 HYSTERESIS_GLYPHS = ("IL", "OZ", "ZHIR", "THOL", "NAV", "RA")
@@ -87,15 +87,7 @@ def _selector_thresholds(G: nx.Graph) -> dict:
 
 def _norms_para_selector(G: nx.Graph) -> dict:
     """Calcula y guarda en ``G.graph`` los máximos para normalizar |ΔNFR| y |d2EPI/dt2|."""
-    dnfr_max = max(
-        (abs(get_attr(nd, ALIAS_DNFR, 0.0)) for _, nd in G.nodes(data=True)),
-        default=0.0,
-    )
-    accel_max = max(
-        (abs(get_attr(nd, ALIAS_D2EPI, 0.0)) for _, nd in G.nodes(data=True)),
-        default=0.0,
-    )
-    norms = {"dnfr_max": float(dnfr_max), "accel_max": float(accel_max)}
+    norms = compute_dnfr_accel_max(G)
     G.graph["_sel_norms"] = norms
     return norms
 

--- a/tests/test_selector_norms.py
+++ b/tests/test_selector_norms.py
@@ -11,11 +11,13 @@ def _make_graph(graph_canon):
     return G
 
 
-def test_default_selector_does_not_compute_norms(graph_canon):
+def test_default_selector_computes_norms(graph_canon):
     G = _make_graph(graph_canon)
     G.graph["glyph_selector"] = default_glyph_selector
     step(G, use_Si=False, apply_glyphs=True)
-    assert "_sel_norms" not in G.graph
+    assert "_sel_norms" in G.graph
+    assert "dnfr_max" in G.graph["_sel_norms"]
+    assert "accel_max" in G.graph["_sel_norms"]
 
 
 def test_parametric_selector_computes_norms(graph_canon):


### PR DESCRIPTION
## Summary
- add `compute_dnfr_accel_max` to compute global |ΔNFR| and acceleration maxima
- use shared helper in default selector, parametric helper and diagnosis metrics
- ensure `_sel_norms` is updated each step and adjust tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5ad06e3e883219590572ab9bf39df