### PR TITLE
refactor: reuse common glyph sequences

### DIFF
--- a/src/tnfr/presets.py
+++ b/src/tnfr/presets.py
@@ -3,20 +3,25 @@ from __future__ import annotations
 from .program import seq, block, wait, ejemplo_canonico_basico
 from .types import Glyph
 
+# Secuencias comunes
+ARRANQUE_BASICO = seq(Glyph.AL, Glyph.EN)
+CIERRE_BASICO = seq(Glyph.RA, Glyph.SHA)
+NUCLEO_VAL_UM = seq(Glyph.VAL, Glyph.UM)
+
 
 _PRESETS = {
-    "arranque_resonante": seq(Glyph.AL, Glyph.EN, Glyph.IL, Glyph.RA, Glyph.VAL, Glyph.UM, wait(3), Glyph.SHA),
-    "mutacion_contenida": seq(Glyph.AL, Glyph.EN, block(Glyph.OZ, Glyph.ZHIR, Glyph.IL, repeat=2), Glyph.RA, Glyph.SHA),
-    "exploracion_acople": seq(
-        Glyph.AL,
-        Glyph.EN,
-        Glyph.IL,
-        Glyph.VAL,
-        Glyph.UM,
-        block(Glyph.OZ, Glyph.NAV, Glyph.IL, repeat=1),
-        Glyph.RA,
-        Glyph.SHA,
-    ),
+    "arranque_resonante": ARRANQUE_BASICO
+    + seq(Glyph.IL, Glyph.RA)
+    + NUCLEO_VAL_UM
+    + seq(wait(3), Glyph.SHA),
+    "mutacion_contenida": ARRANQUE_BASICO
+    + seq(block(Glyph.OZ, Glyph.ZHIR, Glyph.IL, repeat=2))
+    + CIERRE_BASICO,
+    "exploracion_acople": ARRANQUE_BASICO
+    + seq(Glyph.IL)
+    + NUCLEO_VAL_UM
+    + seq(block(Glyph.OZ, Glyph.NAV, Glyph.IL, repeat=1))
+    + CIERRE_BASICO,
     "ejemplo_canonico": ejemplo_canonico_basico(),
     # Topologías fractales: expansión/contracción modular
     "fractal_expand": seq(block(Glyph.THOL, Glyph.VAL, Glyph.UM, repeat=2, close=Glyph.NUL), Glyph.RA),


### PR DESCRIPTION
## Summary
- define descriptive variables for common glyph sequences
- reuse them in `_PRESETS` to avoid duplicating glyph definitions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5b0e545b08321baec06ef922b34b4