### PR TITLE
Expose configurable jitter cache size

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ node ids under `G.graph['_node_sample']`. Operators may use this to avoid
 scanning the whole network. Sampling is skipped automatically when the graph
 has fewer than **50 nodes**, in which case all nodes are included.
 
+### Jitter RNG cache
+
+`random_jitter` uses an LRU cache of `random.Random` instances keyed by `(seed, node)`.
+`JITTER_CACHE_SIZE` controls the maximum number of cached generators (default: `256`).
+Increase it for large graphs or heavy jitter usage, or lower it to save memory.
+
 ---
 
 ## Trained GPT

--- a/src/tnfr/constants/core.py
+++ b/src/tnfr/constants/core.py
@@ -72,6 +72,7 @@ class CoreDefaults:
     NAV_RANDOM: bool = True
     NAV_STRICT: bool = False
     RANDOM_SEED: int = 0
+    JITTER_CACHE_SIZE: int = 256
     OZ_NOISE_MODE: bool = False
     OZ_SIGMA: float = 0.1
     GRAMMAR: Dict[str, Any] = field(

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -78,10 +78,7 @@ def _jitter_base(seed: int, key: int) -> random.Random:
 
 
 # Global cache for deterministic jitter generators
-JITTER_CACHE_SIZE = 256
-
-
-@lru_cache(maxsize=JITTER_CACHE_SIZE)
+@lru_cache(maxsize=DEFAULTS["JITTER_CACHE_SIZE"])
 def _get_jitter_rng_pair(seed: int, key: int) -> random.Random:
     """Return cached ``random.Random`` keyed by seed and node."""
     return _jitter_base(seed, key)
@@ -115,7 +112,7 @@ def random_jitter(
 
     The value is derived from ``(RANDOM_SEED, node.offset())`` and does not store
     references to nodes. By default a global LRU cache of ``seed_key → random.Random``
-    instances (``maxsize={JITTER_CACHE_SIZE}``) advances deterministic sequences across calls.
+    instances (``maxsize={DEFAULTS['JITTER_CACHE_SIZE']}``) advances deterministic sequences across calls.
     When ``cache`` is provided, it is used instead and must handle its own purging
     policy. The global cache discards least recently used generators when the limit
     is exceeded.


### PR DESCRIPTION
## Summary
- add `JITTER_CACHE_SIZE` constant (default 256)
- use configuration for `_get_jitter_rng` cache in `operators`
- document jitter RNG cache parameter in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5b1f1feec83219c1ee29b7ee568f9