### PR TITLE
Mark dynamics benchmark as slow test

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = -m "not slow"
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')

--- a/tests/test_dynamics_benchmark.py
+++ b/tests/test_dynamics_benchmark.py
@@ -1,10 +1,12 @@
 """Pruebas de dynamics benchmark."""
 import time
 import networkx as nx
+import pytest
 
 from tnfr.dynamics import default_compute_delta_nfr
 from tnfr.constants import ALIAS_THETA, ALIAS_EPI, ALIAS_VF
 
+@pytest.mark.slow
 def test_default_compute_delta_nfr_performance():
     """Simple benchmark to ensure the optimized computation runs quickly."""
     G = nx.gnp_random_graph(200, 0.1, seed=1)


### PR DESCRIPTION
## Summary
- tag default delta NFR performance benchmark with `pytest.mark.slow`
- configure pytest to skip slow tests by default and document `slow` marker

## Testing
- `PYTHONPATH=src pytest tests/test_dynamics_benchmark.py -vv`
- `PYTHONPATH=src pytest tests/test_dynamics_benchmark.py -vv -m slow`


------
https://chatgpt.com/codex/tasks/task_e_68b5b4eb27708321a3f697249bdaf196