### PR TITLE
Rechazar combinación de preset y sequence en CLI

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -294,6 +294,9 @@ def cmd_run(args: argparse.Namespace) -> int:
 
 
 def cmd_sequence(args: argparse.Namespace) -> int:
+    if args.preset and args.sequence_file:
+        logger.error("No se puede usar --preset y --sequence-file al mismo tiempo")
+        return 1
     if args.preset:
         program = get_preset(args.preset)
     elif args.sequence_file:


### PR DESCRIPTION
## Summary
- Evitar que `cmd_sequence` permita usar `--preset` y `--sequence-file` simultáneamente
- Mostrar error y terminar con código distinto de cero si se detectan ambos argumentos

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b5b5d18ab8832180fcd0fa3329f251