### PR TITLE
Remove unnecessary float conversions

### DIFF
--- a/src/tnfr/gamma.py
+++ b/src/tnfr/gamma.py
@@ -59,7 +59,7 @@ def _kuramoto_common(G, node, cfg):
     cache = G.graph.get("_kuramoto_cache", {})
     R = float(cache.get("R", 0.0))
     psi = float(cache.get("psi", 0.0))
-    th_i = float(get_attr(G.nodes[node], ALIAS_THETA, 0.0))
+    th_i = get_attr(G.nodes[node], ALIAS_THETA, 0.0)
     return th_i, R, psi
 
 

--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -74,7 +74,7 @@ def coherence_matrix(G):
     # Precompute indices to avoid repeated list.index calls within loops
     node_to_index = {node: idx for idx, node in enumerate(nodes)}
 
-    epi_vals = [float(get_attr(G.nodes[v], ALIAS_EPI, 0.0)) for v in nodes]
+    epi_vals = [get_attr(G.nodes[v], ALIAS_EPI, 0.0) for v in nodes]
     vf_vals = [get_attr(G.nodes[v], ALIAS_VF, 0.0) for v in nodes]
     epi_min, epi_max = min(epi_vals), max(epi_vals)
     vf_min, vf_max = min(vf_vals), max(vf_vals)
@@ -182,7 +182,7 @@ def local_phase_sync_weighted(G, n, nodes_order=None, W_row=None, node_to_index=
     # --- Caso sin pesos ---
     if W_row is None or nodes_order is None:
         vec = [
-            cmath.exp(1j * float(get_attr(G.nodes[v], ALIAS_THETA, 0.0)))
+            cmath.exp(1j * get_attr(G.nodes[v], ALIAS_THETA, 0.0))
             for v in (G.neighbors(n) if neighbors_only else (set(G.nodes()) - {n}))
         ]
         if not vec:
@@ -220,7 +220,7 @@ def local_phase_sync_weighted(G, n, nodes_order=None, W_row=None, node_to_index=
             continue
         w = weights[j]
         den += w
-        th_j = float(get_attr(G.nodes[nj], ALIAS_THETA, 0.0))
+        th_j = get_attr(G.nodes[nj], ALIAS_THETA, 0.0)
         num += w * cmath.exp(1j * th_j)
     return abs(num / den) if den else 0.0
 

--- a/src/tnfr/metrics/diagnosis.py
+++ b/src/tnfr/metrics/diagnosis.py
@@ -16,7 +16,7 @@ from .coherence import local_phase_sync_weighted, _similarity_abs
 
 
 def _dnfr_norm(nd, dnfr_max):
-    val = abs(float(get_attr(nd, ALIAS_DNFR, 0.0)))
+    val = abs(get_attr(nd, ALIAS_DNFR, 0.0))
     if dnfr_max <= 0:
         return 0.0
     x = val / dnfr_max
@@ -25,13 +25,13 @@ def _dnfr_norm(nd, dnfr_max):
 
 def _symmetry_index(G, n, k=3, epi_min=None, epi_max=None):
     nd = G.nodes[n]
-    epi_i = float(get_attr(nd, ALIAS_EPI, 0.0))
+    epi_i = get_attr(nd, ALIAS_EPI, 0.0)
     vec = list(G.neighbors(n))
     if not vec:
         return 1.0
-    epi_bar = fmean(float(get_attr(G.nodes[v], ALIAS_EPI, epi_i)) for v in vec)
+    epi_bar = fmean(get_attr(G.nodes[v], ALIAS_EPI, epi_i) for v in vec)
     if epi_min is None or epi_max is None:
-        epis = [float(get_attr(G.nodes[v], ALIAS_EPI, 0.0)) for v in G.nodes()]
+        epis = [get_attr(G.nodes[v], ALIAS_EPI, 0.0) for v in G.nodes()]
         epi_min, epi_max = min(epis), max(epis)
     return _similarity_abs(epi_i, epi_bar, epi_min, epi_max)
 
@@ -63,7 +63,7 @@ def _diagnosis_step(G, ctx=None):
     norms = compute_dnfr_accel_max(G)
     G.graph["_sel_norms"] = norms
     dnfr_max = float(norms.get("dnfr_max", 1.0)) or 1.0
-    epi_vals = [float(get_attr(G.nodes[v], ALIAS_EPI, 0.0)) for v in G.nodes()]
+    epi_vals = [get_attr(G.nodes[v], ALIAS_EPI, 0.0) for v in G.nodes()]
     epi_min, epi_max = (min(epi_vals) if epi_vals else 0.0), (max(epi_vals) if epi_vals else 1.0)
 
     CfgW = G.graph.get("COHERENCE", COHERENCE)
@@ -80,7 +80,7 @@ def _diagnosis_step(G, ctx=None):
     for i, n in enumerate(nodes):
         nd = G.nodes[n]
         Si = clamp01(get_attr(nd, ALIAS_SI, 0.0))
-        EPI = float(get_attr(nd, ALIAS_EPI, 0.0))
+        EPI = get_attr(nd, ALIAS_EPI, 0.0)
         vf = get_attr(nd, ALIAS_VF, 0.0)
         dnfr_n = _dnfr_norm(nd, dnfr_max)
 

--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -64,7 +64,7 @@ def _weight(G, n, mode: str) -> float:
     if mode == "Si":
         return clamp01(get_attr(nd, ALIAS_SI, 0.5))
     if mode == "EPI":
-        return max(0.0, float(get_attr(nd, ALIAS_EPI, 0.0)))
+        return max(0.0, get_attr(nd, ALIAS_EPI, 0.0))
     return 1.0
 
 

--- a/src/tnfr/validators.py
+++ b/src/tnfr/validators.py
@@ -13,10 +13,10 @@ def _validate_epi_vf(G) -> None:
         for k in ("EPI_MIN", "EPI_MAX", "VF_MIN", "VF_MAX")
     }
     for n, data in G.nodes(data=True):
-        epi = float(get_attr(data, ALIAS_EPI, 0.0, strict=True))
+        epi = get_attr(data, ALIAS_EPI, 0.0, strict=True)
         if not (cfg["EPI_MIN"] - 1e-9 <= epi <= cfg["EPI_MAX"] + 1e-9):
             raise ValueError(f"EPI fuera de rango en nodo {n}: {epi}")
-        vf = float(get_attr(data, ALIAS_VF, 0.0, strict=True))
+        vf = get_attr(data, ALIAS_VF, 0.0, strict=True)
         if not (cfg["VF_MIN"] - 1e-9 <= vf <= cfg["VF_MAX"] + 1e-9):
             raise ValueError(f"VF fuera de rango en nodo {n}: {vf}")
 


### PR DESCRIPTION
## Summary
- Drop redundant `float()` wrappers around `get_attr` calls in validators, sensing, gamma, coherence, and diagnosis modules.

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5baed0dcc8321a6aebf977f9a9a3c