### PR TITLE
Refactor neighbor angle aggregation in compute_Si

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -690,11 +690,8 @@ def compute_Si(G, *, inplace: bool = True) -> Dict[Any, float]:
         neigh = list(G.neighbors(n))
         deg = len(neigh)
         if deg:
-            sum_cos = 0.0
-            sum_sin = 0.0
-            for v in neigh:
-                sum_cos += cos_th[v]
-                sum_sin += sin_th[v]
+            sum_cos = sum(cos_th[v] for v in neigh)
+            sum_sin = sum(sin_th[v] for v in neigh)
             mean_cos = sum_cos / deg
             mean_sin = sum_sin / deg
             th_bar = math.atan2(mean_sin, mean_cos)


### PR DESCRIPTION
## Summary
- Simplify computation of mean neighbor phase in `compute_Si` using generator-based sums
- Remove unnecessary temporary variables

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5be3cfe008321a77d46445d004480