### PR TITLE
feat: centralize iterable handling with ensure_collection

### DIFF
--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -1,14 +1,13 @@
 """Reglas de gramática."""
 from __future__ import annotations
 from typing import Dict, Any, Set, Iterable, Optional
-from collections.abc import Collection
 
 from .constants import (
     DEFAULTS,
     ALIAS_SI, ALIAS_DNFR,
     get_param,
 )
-from .helpers import get_attr, clamp01, reciente_glifo
+from .helpers import get_attr, clamp01, reciente_glifo, ensure_collection
 from tnfr.types import Glyph
 
 # Glifos nominales (para evitar typos)
@@ -174,9 +173,7 @@ def apply_glyph_with_grammar(G, nodes: Optional[Iterable[Any]], glyph: Glyph | s
         window = get_param(G, "GLYPH_HYSTERESIS_WINDOW")
 
     g_str = glyph.value if isinstance(glyph, Glyph) else str(glyph)
-    iter_nodes = G.nodes() if nodes is None else nodes
-    if not isinstance(iter_nodes, Collection):
-        iter_nodes = list(iter_nodes)
+    iter_nodes = ensure_collection(G.nodes() if nodes is None else nodes)
     for n in iter_nodes:
         g_eff = enforce_canonical_grammar(G, n, g_str)
         aplicar_glifo(G, n, g_eff, window=window)

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -1,6 +1,7 @@
 """Funciones auxiliares."""
 from __future__ import annotations
 from typing import Iterable, Dict, Any, Callable, TypeVar, TYPE_CHECKING
+from collections.abc import Collection
 import logging
 import math
 from collections import deque, Counter
@@ -34,6 +35,7 @@ T = TypeVar("T")
 __all__ = [
     "read_structured_file",
     "ensure_parent",
+    "ensure_collection",
     "clamp",
     "clamp_abs",
     "clamp01",
@@ -106,6 +108,14 @@ def read_structured_file(path: Path) -> Any:
 def ensure_parent(path: str | Path) -> None:
     """Crea el directorio padre de ``path`` si hace falta."""
     Path(path).parent.mkdir(parents=True, exist_ok=True)
+
+# -------------------------
+# Iterables y colecciones
+# -------------------------
+
+def ensure_collection(it: Iterable[T]) -> Collection[T]:
+    """Devuelve ``it`` si ya es ``Collection`` o ``list(it)`` en caso contrario."""
+    return it if isinstance(it, Collection) else list(it)
 
 # -------------------------
 # Utilidades numéricas

--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -1,13 +1,13 @@
 """Lenguaje de programación TNFR."""
 from __future__ import annotations
 from typing import Any, Callable, Iterable, List, Optional, Sequence, Tuple, Union
-from collections.abc import Collection
 from dataclasses import dataclass
 from contextlib import contextmanager
 from collections import deque
 
 from .constants import get_param
 from .grammar import apply_glyph_with_grammar
+from .helpers import ensure_collection
 from .sense import GLYPHS_CANONICAL_SET
 from .types import Glyph
 
@@ -96,10 +96,7 @@ def _apply_glyph_to_targets(G, g: Glyph | str, nodes: Optional[Iterable[Node]] =
     are materialised as a ``list`` only when the active selector requires
     index-based access.
     """
-    if nodes is None:
-        nodes = _all_nodes(G)
-    elif not isinstance(nodes, Collection):
-        nodes = list(nodes)
+    nodes = ensure_collection(_all_nodes(G) if nodes is None else nodes)
     w = _window(G)
     apply_glyph_with_grammar(G, nodes, g, w)
 


### PR DESCRIPTION
## Summary
- add `ensure_collection` helper to normalize iterables
- refactor grammar and program modules to use `ensure_collection`
- update imports accordingly

## Testing
- `pip install -e .`
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5c20703f483219b88a35af3e57209