### PR TITLE
Warn on negative weights

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -171,6 +171,8 @@ def normalize_weights(dict_like: Dict[str, Any], keys: Iterable[str], default: f
     """
     keys = list(keys)
     weights = {k: float(dict_like.get(k, default)) for k in keys}
+    if any(v < 0 for v in weights.values()):
+        logging.warning("Pesos negativos detectados: %s", weights)
     total = sum(weights.values())
     n = len(keys)
     if total <= 0:

--- a/tests/test_normalize_weights.py
+++ b/tests/test_normalize_weights.py
@@ -1,0 +1,16 @@
+"""Tests for normalize_weights helper."""
+import logging
+from tnfr.helpers import normalize_weights
+
+
+def test_normalize_weights_warns_on_negative_value(caplog):
+    weights = {"a": -1.0, "b": 2.0}
+    with caplog.at_level("WARNING"):
+        normalize_weights(weights, ("a", "b"))
+    assert any("Pesos negativos" in m for m in caplog.messages)
+
+
+def test_normalize_weights_warns_on_negative_default(caplog):
+    with caplog.at_level("WARNING"):
+        normalize_weights({}, ("a", "b"), default=-0.5)
+    assert any("Pesos negativos" in m for m in caplog.messages)


### PR DESCRIPTION
## Summary
- log a warning in `normalize_weights` when any provided weight is negative
- add tests asserting that negative weights and defaults trigger a warning

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c2f777388321a276b0a304af8ba2