### PR TITLE
Use edge version counter for dnfr cache

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -89,7 +89,7 @@ def _cached_nodes_and_A(
     antigua."""
 
     cache: OrderedDict = G.graph.setdefault("_dnfr_cache", OrderedDict())
-    key = frozenset(G.edges)
+    key = (int(G.graph.get("_edge_version", 0)), G.number_of_nodes())
     nodes_and_A = cache.get(key)
     if nodes_and_A is None:
         nodes = list(G.nodes())

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -64,6 +64,7 @@ __all__ = [
     "compute_dnfr_accel_max",
     "compute_coherence",
     "compute_Si",
+    "increment_edge_version",
 ]
 
 # -------------------------
@@ -720,3 +721,14 @@ def compute_Si(G, *, inplace: bool = True) -> Dict[Any, float]:
         if inplace:
             set_attr(nd, ALIAS_SI, Si)
     return out
+
+
+def increment_edge_version(G: Any) -> None:
+    """Incrementa el contador de versión de aristas en ``G.graph``.
+
+    Acepta un ``nx.Graph`` o un diccionario que actúe como ``G.graph`` y
+    actualiza ``"_edge_version"`` para invalidar caches dependientes de las
+    aristas.
+    """
+    graph = G.graph if hasattr(G, "graph") else G
+    graph["_edge_version"] = int(graph.get("_edge_version", 0)) + 1

--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -22,6 +22,7 @@ from .helpers import (
     set_attr_str,
     set_vf,
     set_dnfr,
+    increment_edge_version,
 )
 
 from .operators import aplicar_glifo_obj
@@ -153,6 +154,7 @@ class NodoTNFR:
             raise ValueError("Edge weight must be non-negative")
         self._neighbors[other] = weight
         other._neighbors[self] = weight
+        increment_edge_version(self.graph)
 
     def push_glifo(self, glifo: str, window: int) -> None:
         nd = {"hist_glifos": self._hist_glifos}
@@ -220,6 +222,7 @@ class NodoNX(NodoProtocol):
             if weight < 0:
                 raise ValueError("Edge weight must be non-negative")
             self.G.add_edge(self.n, other.n, weight=weight)
+            increment_edge_version(self.G)
         else:
             raise NotImplementedError
 

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -19,6 +19,7 @@ from .helpers import (
     get_attr,
     set_attr,
     fase_media,
+    increment_edge_version,
 )
 if TYPE_CHECKING:
     from .node import NodoProtocol, NodoNX
@@ -636,11 +637,14 @@ def aplicar_remesh_red_topologico(
             # clear_edges está disponible desde NetworkX 2.4 y evita materializar la lista
             # completa de aristas; tnfr requiere NetworkX>=2.6 (ver pyproject.toml)
             G.clear_edges()
+            increment_edge_version(G)
             G.remove_nodes_from(list(G.nodes()))
+            increment_edge_version(G)
             for idx in C.nodes():
                 data = dict(C.nodes[idx])
                 G.add_node(idx, **data)
             G.add_edges_from(new_edges)
+            increment_edge_version(G)
 
             if G.graph.get("REMESH_LOG_EVENTS", REMESH_DEFAULTS["REMESH_LOG_EVENTS"]):
                 ev = G.graph.setdefault("history", {}).setdefault("remesh_events", [])
@@ -678,7 +682,9 @@ def aplicar_remesh_red_topologico(
 
     # clear_edges disponible en NetworkX >=2.4; tnfr depende de >=2.6
     G.clear_edges()
+    increment_edge_version(G)
     G.add_edges_from(new_edges)
+    increment_edge_version(G)
 
 def aplicar_remesh_si_estabilizacion_global(G, pasos_estables_consecutivos: Optional[int] = None) -> None:
     # Ventanas y umbrales

--- a/tests/test_dnfr_cache.py
+++ b/tests/test_dnfr_cache.py
@@ -4,7 +4,7 @@ import networkx as nx
 
 from tnfr.dynamics import default_compute_delta_nfr
 from tnfr.constants import ALIAS_THETA, ALIAS_EPI, ALIAS_VF, ALIAS_DNFR
-from tnfr.helpers import get_attr
+from tnfr.helpers import get_attr, increment_edge_version
 
 
 def _setup_graph():
@@ -29,6 +29,7 @@ def test_cache_invalidated_on_graph_change(vectorized):
     before = [get_attr(G.nodes[n], ALIAS_DNFR, 0.0) for n in G.nodes]
 
     G.add_edge(2, 3)  # Cambia número de nodos y aristas
+    increment_edge_version(G)
     G.graph["vectorized_dnfr"] = vectorized
     default_compute_delta_nfr(G, cache_size=2)
     assert len(G.graph.get("_dnfr_cache", {})) == 2
@@ -38,6 +39,7 @@ def test_cache_invalidated_on_graph_change(vectorized):
     assert before[2] != pytest.approx(after[2])
 
     G.add_edge(3, 4)
+    increment_edge_version(G)
     G.graph["vectorized_dnfr"] = vectorized
     default_compute_delta_nfr(G, cache_size=2)
     assert len(G.graph.get("_dnfr_cache", {})) == 2


### PR DESCRIPTION
## Summary
- Replace expensive edge frozenset cache key with `(edge_version, node_count)`
- Track edge changes via `increment_edge_version` helper and call from graph mutators
- Update DNFR cache test to bump edge version when mutating graph

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c42ee64483218874b4de58327bd0