### PR TITLE
Validate jitter amplitude

### DIFF
--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -119,7 +119,9 @@ def random_jitter(
     is exceeded.
     """
 
-    if amplitude == 0:
+    if amplitude <= 0:
+        if amplitude < 0:
+            raise ValueError("amplitude must be positive")
         return 0.0
 
     base_seed = int(node.graph.get("RANDOM_SEED", 0))

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -4,6 +4,7 @@ from tnfr.operators import random_jitter, clear_jitter_cache
 from tnfr.operators import op_UM
 from tnfr.constants import attach_defaults
 import networkx as nx
+import pytest
 
 
 def test_random_jitter_deterministic_with_and_without_cache(graph_canon):
@@ -34,6 +35,21 @@ def test_random_jitter_deterministic_with_and_without_cache(graph_canon):
     cache2 = {}
     seq = [random_jitter(n0, 0.5, cache2) for _ in range(2)]
     assert seq == [j5, j6]
+
+
+def test_random_jitter_zero_amplitude(graph_canon):
+    G = graph_canon()
+    G.add_node(0)
+    n0 = NodoNX(G, 0)
+    assert random_jitter(n0, 0.0) == 0.0
+
+
+def test_random_jitter_negative_amplitude(graph_canon):
+    G = graph_canon()
+    G.add_node(0)
+    n0 = NodoNX(G, 0)
+    with pytest.raises(ValueError):
+        random_jitter(n0, -0.1)
 
 
 def test_um_candidate_subset_proximity():


### PR DESCRIPTION
## Summary
- Validate `random_jitter` amplitude, raising `ValueError` for negatives and returning 0.0 for zero.
- Test zero and negative amplitudes in `random_jitter`.

## Testing
- `python -m pytest tests/test_operators.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c5859a988321b1c5fac52a28b433