### PR TITLE
Refactor glyph groups for metrics and observers

### DIFF
--- a/src/tnfr/constants_glifos.py
+++ b/src/tnfr/constants_glifos.py
@@ -24,6 +24,18 @@ DISRUPTIVOS = (
     Glyph.THOL.value,
 )
 
+# Mapa general de agrupaciones glíficas para referencia cruzada.
+GLYPH_GROUPS = {
+    "estabilizadores": ESTABILIZADORES,
+    "disruptivos": DISRUPTIVOS,
+    # Grupos auxiliares para métricas morfosintácticas
+    "ID": (Glyph.OZ.value,),
+    "CM": (Glyph.ZHIR.value, Glyph.NAV.value),
+    "NE": (Glyph.IL.value, Glyph.THOL.value),
+    "PP_num": (Glyph.SHA.value,),
+    "PP_den": (Glyph.REMESH.value,),
+}
+
 # -------------------------
 # Mapa de ángulos glíficos
 # -------------------------

--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -9,6 +9,7 @@ import heapq
 from ..constants import METRIC_DEFAULTS, ALIAS_EPI, METRICS
 from ..helpers import register_callback, ensure_history, last_glifo, get_attr
 from ..sense import GLYPHS_CANONICAL
+from ..constants_glifos import GLYPH_GROUPS
 from .coherence import register_coherence_callbacks
 from .diagnosis import register_diagnosis_callbacks
 
@@ -114,20 +115,17 @@ def _update_epi_support(G, hist, t, thr):
 
 def _update_morph_metrics(G, hist, counts, t):
     """Registra métricas morfosintácticas basadas en conteos glíficos."""
-    oz = counts.get("OZ", 0)
-    zhir = counts.get("ZHIR", 0)
-    nav = counts.get("NAV", 0)
-    il = counts.get("IL", 0)
-    thol = counts.get("THOL", 0)
-    remesh = counts.get("REMESH", 0)
-    sha = counts.get("SHA", 0)
-
+    get_count = lambda keys: sum(counts.get(k, 0) for k in keys)
     total = max(1, sum(counts.values()))
-    id_val = oz / total
-    cm_val = (zhir + nav) / total
-    ne_val = (il + thol) / total
-    pp_val = 0.0 if remesh == 0 else sha / remesh
-    hist.setdefault("morph", []).append({"t": t, "ID": id_val, "CM": cm_val, "NE": ne_val, "PP": pp_val})
+    id_val = get_count(GLYPH_GROUPS.get("ID", ())) / total
+    cm_val = get_count(GLYPH_GROUPS.get("CM", ())) / total
+    ne_val = get_count(GLYPH_GROUPS.get("NE", ())) / total
+    num = get_count(GLYPH_GROUPS.get("PP_num", ()))
+    den = get_count(GLYPH_GROUPS.get("PP_den", ()))
+    pp_val = 0.0 if den == 0 else num / den
+    hist.setdefault("morph", []).append(
+        {"t": t, "ID": id_val, "CM": cm_val, "NE": ne_val, "PP": pp_val}
+    )
 
 
 # -------------

--- a/src/tnfr/observers.py
+++ b/src/tnfr/observers.py
@@ -12,7 +12,7 @@ from .helpers import (
     count_glyphs,
     compute_coherence,
 )
-from .constants_glifos import ESTABILIZADORES, DISRUPTIVOS
+from .constants_glifos import GLYPH_GROUPS
 from .gamma import kuramoto_R_psi
 
 # -------------------------
@@ -93,19 +93,9 @@ def carga_glifica(G, window: int | None = None) -> dict:
     # Proporciones por glifo
     dist = {k: v / count for k, v in total.items()}
 
-    # Agregados conceptuales (puedes ajustar categorías)
-    # Glifos que consolidan la coherencia nodal: IL estabiliza el flujo (cap. 6),
-    # RA propaga la resonancia (cap. 9), UM acopla nodos en fase (cap. 8)
-    # y SHA ofrece silencio regenerativo (cap. 10). Véase manual TNFR,
-    # sec. 18.19 "Análisis morfosintáctico" para la taxonomía funcional.
-    # Glifos que perturban o reconfiguran la red: OZ introduce disonancia
-    # evolutiva (cap. 7), ZHIR muta la estructura (cap. 14), NAV marca
-    # el tránsito entre estados (cap. 15) y THOL autoorganiza un nuevo
-    # orden (cap. 13). Véase manual TNFR, sec. 18.19 para esta clasificación.
+    for label, glyphs in GLYPH_GROUPS.items():
+        dist[f"_{label}"] = sum(dist.get(k, 0.0) for k in glyphs)
 
-
-    dist["_estabilizadores"] = sum(dist.get(k, 0.0) for k in ESTABILIZADORES)
-    dist["_disruptivos"] = sum(dist.get(k, 0.0) for k in DISRUPTIVOS)
     dist["_count"] = count
     return dist
 

--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -46,8 +46,7 @@ def test_carga_glifica_uses_module_constants(monkeypatch, graph_canon):
     G.add_node(1, hist_glifos=["B"])
 
     # Patch constants to custom categories
-    monkeypatch.setattr("tnfr.observers.ESTABILIZADORES", ["A"])  # type: ignore[attr-defined]
-    monkeypatch.setattr("tnfr.observers.DISRUPTIVOS", ["B"])  # type: ignore[attr-defined]
+    monkeypatch.setattr("tnfr.observers.GLYPH_GROUPS", {"estabilizadores": ["A"], "disruptivos": ["B"]})
 
     dist = carga_glifica(G)
 


### PR DESCRIPTION
## Summary
- expose shared `GLYPH_GROUPS` map with canonical glyph categories
- compute morph metrics using `GLYPH_GROUPS`
- reuse `GLYPH_GROUPS` in `carga_glifica`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5c87892a883218a141dab2af0b448