### PR TITLE
Make node attribute initialization optional in preparar_red

### DIFF
--- a/src/tnfr/ontosim.py
+++ b/src/tnfr/ontosim.py
@@ -10,7 +10,25 @@ from .initialization import init_node_attrs
 
 # API de alto nivel
 
-def preparar_red(G: nx.Graph, *, override_defaults: bool = False, **overrides) -> nx.Graph:
+def preparar_red(
+    G: nx.Graph,
+    *,
+    init_attrs: bool = True,
+    override_defaults: bool = False,
+    **overrides,
+) -> nx.Graph:
+    """Prepara ``G`` para simulación.
+
+    Parameters
+    ----------
+    init_attrs:
+        Ejecuta ``init_node_attrs`` si es ``True`` (por defecto),
+        dejando los atributos de nodos intactos cuando es ``False``.
+    override_defaults:
+        Si ``True``, `attach_defaults` sobreescribe entradas existentes.
+    **overrides:
+        Parámetros para aplicar tras la fase de defaults.
+    """
     attach_defaults(G, override=override_defaults)
     if overrides:
         from .constants import merge_overrides
@@ -63,8 +81,9 @@ def preparar_red(G: nx.Graph, *, override_defaults: bool = False, **overrides) -
     })
     G.graph.setdefault("_CALLBACKS_DOC",
         "Interfaz Γ(R): registrar pares (name, func) con firma (G, ctx) en callbacks['before_step'|'after_step'|'on_remesh']")
-    
-    init_node_attrs(G, override=True)
+
+    if init_attrs:
+        init_node_attrs(G, override=True)
     return G
 
 def step(G: nx.Graph, *, dt: float | None = None, use_Si: bool = True, apply_glyphs: bool = True) -> None:

--- a/tests/test_preparar_red.py
+++ b/tests/test_preparar_red.py
@@ -1,0 +1,16 @@
+import networkx as nx
+
+from tnfr.ontosim import preparar_red
+
+
+def test_preparar_red_init_attrs_por_defecto():
+    G = nx.path_graph(3)
+    preparar_red(G)
+    assert all('θ' in d for _, d in G.nodes(data=True))
+
+
+def test_preparar_red_sin_init_attrs():
+    G = nx.path_graph(3)
+    preparar_red(G, init_attrs=False)
+    assert all('θ' not in d for _, d in G.nodes(data=True))
+


### PR DESCRIPTION
## Summary
- allow skipping node attribute initialization via `init_attrs` flag in `preparar_red`
- document the new argument and guard `init_node_attrs` call
- add tests covering both initialization paths

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5cbd0b2f48321b2470bbe6ab5e0dc