### PR TITLE
Manejar dependencia faltante en lectura de archivos estructurados

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -110,6 +110,10 @@ def read_structured_file(path: Path) -> Any:
         raise ValueError(f"Error al parsear archivo JSON en {path}: {e}") from e
     except YAMLError as e:
         raise ValueError(f"Error al parsear archivo YAML en {path}: {e}") from e
+    except RuntimeError as e:
+        raise ValueError(
+            f"Dependencia faltante al parsear {path}: {e}"
+        ) from e
 
 
 def ensure_parent(path: str | Path) -> None:

--- a/tests/test_read_structured_file_errors.py
+++ b/tests/test_read_structured_file_errors.py
@@ -1,6 +1,8 @@
 """Pruebas de read structured file errors."""
 import pytest
 from pathlib import Path
+import tnfr.helpers as helpers
+
 from tnfr.helpers import read_structured_file
 
 
@@ -45,3 +47,18 @@ def test_read_structured_file_corrupt_yaml(tmp_path: Path):
     msg = str(excinfo.value)
     assert "YAML" in msg
     assert str(path) in msg
+
+
+def test_read_structured_file_missing_dependency(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    path = tmp_path / "data.yaml"
+    path.write_text("a: 1", encoding="utf-8")
+
+    def fake_parser(_: str) -> None:
+        raise RuntimeError("pyyaml no está instalado")
+
+    monkeypatch.setitem(helpers.PARSERS, ".yaml", fake_parser)
+
+    with pytest.raises(ValueError) as excinfo:
+        read_structured_file(path)
+    msg = str(excinfo.value)
+    assert "pyyaml" in msg


### PR DESCRIPTION
## Summary
- Convert YAML parser RuntimeError into a ValueError indicating missing dependency
- Test missing dependency error path in `read_structured_file`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5d0301fd083219ef32f23d56fc9a9