### PR TITLE
Improve weight normalization precision and strictness

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -136,7 +136,7 @@ def _write_dnfr_metadata(G, *, weights: dict, hook_name: str, note: str | None =
     """Escribe en G.graph un bloque _DNFR_META con la mezcla y el nombre del hook.
 
     `weights` puede incluir componentes arbitrarias (phase/epi/vf/topo/etc.)."""
-    total = sum(float(v) for v in weights.values())
+    total = math.fsum(float(v) for v in weights.values())
     if total <= 0:
         # si no hay pesos, normalizamos a componentes iguales
         n = max(1, len(weights))

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -162,18 +162,32 @@ def angle_diff(a: float, b: float) -> float:
     return _wrap_angle(a - b)
 
 
-def normalize_weights(dict_like: Dict[str, Any], keys: Iterable[str], default: float = 0.0) -> Dict[str, float]:
+def normalize_weights(
+    dict_like: Dict[str, Any],
+    keys: Iterable[str],
+    default: float = 0.0,
+    *,
+    error_on_negative: bool = False,
+) -> Dict[str, float]:
     """Devuelve ``dict`` de ``keys`` normalizadas a sumatorio 1.
 
     Cada clave en ``keys`` se extrae de ``dict_like`` convirtiéndola a ``float``.
     Si la suma de los valores obtenidos es <= 0, se asignan proporciones
     uniformes entre todas las claves.
+
+    Parameters
+    ----------
+    error_on_negative:
+        Si es ``True`` se lanza :class:`ValueError` ante valores negativos.
+        En caso contrario se registra una advertencia.
     """
     keys = list(keys)
     weights = {k: float(dict_like.get(k, default)) for k in keys}
     if any(v < 0 for v in weights.values()):
+        if error_on_negative:
+            raise ValueError(f"Pesos negativos detectados: {weights}")
         logging.warning("Pesos negativos detectados: %s", weights)
-    total = sum(weights.values())
+    total = math.fsum(weights.values())
     n = len(keys)
     if total <= 0:
         if n == 0:

--- a/tests/test_normalize_weights.py
+++ b/tests/test_normalize_weights.py
@@ -1,5 +1,7 @@
 """Tests for normalize_weights helper."""
 import logging
+import math
+import pytest
 from tnfr.helpers import normalize_weights
 
 
@@ -10,7 +12,25 @@ def test_normalize_weights_warns_on_negative_value(caplog):
     assert any("Pesos negativos" in m for m in caplog.messages)
 
 
+def test_normalize_weights_raises_on_negative_value():
+    weights = {"a": -1.0, "b": 2.0}
+    with pytest.raises(ValueError):
+        normalize_weights(weights, ("a", "b"), error_on_negative=True)
+
+
 def test_normalize_weights_warns_on_negative_default(caplog):
     with caplog.at_level("WARNING"):
         normalize_weights({}, ("a", "b"), default=-0.5)
     assert any("Pesos negativos" in m for m in caplog.messages)
+
+
+def test_normalize_weights_raises_on_negative_default():
+    with pytest.raises(ValueError):
+        normalize_weights({}, ("a", "b"), default=-0.5, error_on_negative=True)
+
+
+def test_normalize_weights_high_precision():
+    weights = {str(i): 0.1 for i in range(10)}
+    norm = normalize_weights(weights, weights.keys())
+    assert all(v == 0.1 for v in norm.values())
+    assert math.isclose(math.fsum(norm.values()), 1.0)


### PR DESCRIPTION
## Summary
- replace `sum` with `math.fsum` for weight totals to improve numeric precision
- add optional `error_on_negative` flag to `normalize_weights` raising `ValueError`
- cover negative and precision cases in tests

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5d55b5d3c8321adee29fa62471892