### PR TITLE
Handle invalid weights gracefully

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -191,11 +191,23 @@ def normalize_weights(
     Parameters
     ----------
     error_on_negative:
-        Si es ``True`` se lanza :class:`ValueError` ante valores negativos.
-        En caso contrario se registra una advertencia.
+        Si es ``True`` se lanza :class:`ValueError` ante valores negativos o
+        pesos no numéricos. En caso contrario se registra una advertencia y se
+        utiliza el valor ``default``.
     """
     keys = list(keys)
-    weights = {k: float(dict_like.get(k, default)) for k in keys}
+    default_float = float(default)
+    weights: Dict[str, float] = {}
+    for k in keys:
+        val = dict_like.get(k, default_float)
+        ok, converted = _convert_value(
+            val,
+            float,
+            strict=error_on_negative,
+            key=k,
+            log_level=logging.WARNING,
+        )
+        weights[k] = converted if ok and converted is not None else default_float
     if any(v < 0 for v in weights.values()):
         if error_on_negative:
             raise ValueError(f"Pesos negativos detectados: {weights}")

--- a/tests/test_normalize_weights.py
+++ b/tests/test_normalize_weights.py
@@ -29,6 +29,21 @@ def test_normalize_weights_raises_on_negative_default():
         normalize_weights({}, ("a", "b"), default=-0.5, error_on_negative=True)
 
 
+def test_normalize_weights_warns_on_non_numeric_value(caplog):
+    weights = {"a": "not-a-number", "b": 2.0}
+    with caplog.at_level("WARNING"):
+        norm = normalize_weights(weights, ("a", "b"), default=1.0)
+    assert any("No se pudo convertir" in m for m in caplog.messages)
+    assert math.isclose(math.fsum(norm.values()), 1.0)
+    assert norm == pytest.approx({"a": 1 / 3, "b": 2 / 3})
+
+
+def test_normalize_weights_raises_on_non_numeric_value():
+    weights = {"a": "not-a-number", "b": 2.0}
+    with pytest.raises(ValueError):
+        normalize_weights(weights, ("a", "b"), error_on_negative=True)
+
+
 def test_normalize_weights_high_precision():
     weights = {str(i): 0.1 for i in range(10)}
     norm = normalize_weights(weights, weights.keys())


### PR DESCRIPTION
## Summary
- avoid crashes in `normalize_weights` when weights cannot be converted to floats by logging a warning and falling back to default
- add tests for invalid weight strings and strict mode behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5db0e3d1883218d65afb9f5465cc3