### PR TITLE
Avoid usage tracking in HistoryDict.get

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -560,6 +560,9 @@ class HistoryDict(dict):
         return val
 
     def get(self, key, default=None):  # type: ignore[override]
+        return super().get(key, default)
+
+    def tracked_get(self, key, default=None):
         if key in self:
             return self[key]
         return default

--- a/src/tnfr/metrics/core.py
+++ b/src/tnfr/metrics/core.py
@@ -176,7 +176,7 @@ def register_metrics_callbacks(G) -> None:
 def Tg_global(G, normalize: bool = True) -> Dict[str, float]:
     """Tiempo glífico total por clase. Si normalize=True, devuelve fracciones del total."""
     hist = ensure_history(G)
-    tg_total: Dict[str, float] = hist.get("Tg_total", {})
+    tg_total: Dict[str, float] = hist.tracked_get("Tg_total", {})
     total = sum(tg_total.values()) or 1.0
     if normalize:
         return {g: float(tg_total.get(g, 0.0)) / total for g in GLYPHS_CANONICAL}
@@ -186,7 +186,7 @@ def Tg_global(G, normalize: bool = True) -> Dict[str, float]:
 def Tg_by_node(G, n, normalize: bool = False) -> Dict[str, float | List[float]]:
     """Resumen por nodo: si normalize, devuelve medias por glifo; si no, lista de corridas."""
     hist = ensure_history(G)
-    rec = hist.get("Tg_by_node", {}).get(n, {})
+    rec = hist.tracked_get("Tg_by_node", {}).get(n, {})
     if not normalize:
         # convertir default dict → list para serializar
         return {g: list(rec.get(g, [])) for g in GLYPHS_CANONICAL}
@@ -200,7 +200,7 @@ def Tg_by_node(G, n, normalize: bool = False) -> Dict[str, float | List[float]]:
 
 def latency_series(G) -> Dict[str, List[float]]:
     hist = ensure_history(G)
-    xs = hist.get("latency_index", [])
+    xs = hist.tracked_get("latency_index", [])
     return {
         "t": [float(x.get("t", i)) for i, x in enumerate(xs)],
         "value": [float(x.get("value", 0.0)) for x in xs],
@@ -209,7 +209,7 @@ def latency_series(G) -> Dict[str, List[float]]:
 
 def glifogram_series(G) -> Dict[str, List[float]]:
     hist = ensure_history(G)
-    xs = hist.get("glifogram", [])
+    xs = hist.tracked_get("glifogram", [])
     if not xs:
         return {"t": []}
     out = {"t": [float(x.get("t", i)) for i, x in enumerate(xs)]}
@@ -227,7 +227,7 @@ def glyph_top(G, k: int = 3) -> List[Tuple[str, float]]:
 def glyph_dwell_stats(G, n) -> Dict[str, Dict[str, float]]:
     """Estadísticos por nodo: mean/median/max de corridas por glifo."""
     hist = ensure_history(G)
-    rec = hist.get("Tg_by_node", {}).get(n, {})
+    rec = hist.tracked_get("Tg_by_node", {}).get(n, {})
     out = {}
     for g in GLYPHS_CANONICAL:
         runs = list(rec.get(g, []))

--- a/src/tnfr/metrics/diagnosis.py
+++ b/src/tnfr/metrics/diagnosis.py
@@ -69,9 +69,9 @@ def _diagnosis_step(G, ctx=None):
     CfgW = G.graph.get("COHERENCE", COHERENCE)
     Wkey = CfgW.get("Wi_history_key", "W_i")
     Wm_key = CfgW.get("history_key", "W_sparse")
-    Wi_series = hist.get(Wkey, [])
+    Wi_series = hist.tracked_get(Wkey, [])
     Wi_last = Wi_series[-1] if Wi_series else None
-    Wm_series = hist.get(Wm_key, [])
+    Wm_series = hist.tracked_get(Wm_key, [])
     Wm_last = Wm_series[-1] if Wm_series else None
 
     nodes = list(G.nodes())
@@ -135,7 +135,7 @@ def dissonance_events(G, ctx=None):
     evs = hist.setdefault("events", [])
     norms = G.graph.get("_sel_norms", {})
     dnfr_max = float(norms.get("dnfr_max", 1.0)) or 1.0
-    step_idx = len(hist.get("C_steps", []))
+    step_idx = len(hist.tracked_get("C_steps", []))
     nodes = list(G.nodes())
     node_to_index = {v: i for i, v in enumerate(nodes)}
     for n in nodes:

--- a/src/tnfr/metrics/export.py
+++ b/src/tnfr/metrics/export.py
@@ -23,10 +23,10 @@ def export_history(G, base_path: str, fmt: str = "csv") -> None:
     hist = ensure_history(G)
     ensure_parent(base_path)
     glifo = glifogram_series(G)
-    sigma_x = hist.get("sense_sigma_x", [])
-    sigma_y = hist.get("sense_sigma_y", [])
-    sigma_mag = hist.get("sense_sigma_mag", [])
-    sigma_angle = hist.get("sense_sigma_angle", [])
+    sigma_x = hist.tracked_get("sense_sigma_x", [])
+    sigma_y = hist.tracked_get("sense_sigma_y", [])
+    sigma_mag = hist.tracked_get("sense_sigma_mag", [])
+    sigma_angle = hist.tracked_get("sense_sigma_angle", [])
     min_len = min(len(sigma_x), len(sigma_y), len(sigma_mag), len(sigma_angle))
     sigma = {
         "t": list(range(min_len)),
@@ -35,8 +35,8 @@ def export_history(G, base_path: str, fmt: str = "csv") -> None:
         "mag": sigma_mag[:min_len],
         "angle": sigma_angle[:min_len],
     }
-    morph = hist.get("morph", [])
-    epi_supp = hist.get("EPI_support", [])
+    morph = hist.tracked_get("morph", [])
+    epi_supp = hist.tracked_get("EPI_support", [])
     fmt = fmt.lower()
     if fmt == "csv":
         ts = glifo.get("t", [])

--- a/tests/test_history_heap_cleanup.py
+++ b/tests/test_history_heap_cleanup.py
@@ -17,3 +17,13 @@ def test_heap_compaction_many_keys():
     for i in range(1000):
         _ = hist[f"k{i % 10}"]
     assert len(hist._heap) <= len(hist) * 2
+
+
+def test_get_does_not_track_usage():
+    hist = HistoryDict()
+    hist["a"] = 1
+    counts_before = dict(hist._counts)
+    heap_before = list(hist._heap)
+    assert hist.get("a") == 1
+    assert hist._counts == counts_before
+    assert hist._heap == heap_before


### PR DESCRIPTION
## Summary
- Stop `HistoryDict.get` from incrementing usage counters and expose `tracked_get` for opt-in tracking
- Replace metric modules' `hist.get` calls with `tracked_get` where usage counts should increase
- Add regression test confirming `.get` does not mutate history bookkeeping

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5dde165f48321ad7f868d21036c56