### PR TITLE
Optimize sigma vector accumulation

### DIFF
--- a/src/tnfr/sense.py
+++ b/src/tnfr/sense.py
@@ -69,12 +69,14 @@ def _weight(G, n, mode: str) -> float:
 
 
 def _node_weight(G, n, weight_mode: str) -> tuple[str, float, complex] | None:
+    """Return ``(glyph, weight, weighted_unit)`` or ``None`` if no glyph."""
     nd = G.nodes[n]
     g = last_glifo(nd)
     if not g:
         return None
     w = _weight(G, n, weight_mode)
-    return g, w, glyph_unit(g) * w
+    z = glyph_unit(g) * w  # precompute weighted unit vector
+    return g, w, z
 
 
 def _sigma_cfg(G):
@@ -173,16 +175,16 @@ def sigma_vector_from_graph(G: nx.Graph, weight_mode: str | None = None) -> Dict
 
     cfg = _sigma_cfg(G)
     weight_mode = weight_mode or cfg.get("weight", "Si")
-    acc = complex(0.0, 0.0)
+    acc_z = complex(0.0, 0.0)
     cnt = 0
     for n in G.nodes():
         nw = _node_weight(G, n, weight_mode)
         if not nw:
             continue
-        g, w, _ = nw
-        acc += glyph_unit(g) * w
+        g, w, z = nw  # z already includes glyph_unit(g) * w
+        acc_z += z
         cnt += 1
-    vec = _sigma_from_acc(acc, cnt)
+    vec = _sigma_from_acc(acc_z, cnt)
     vec["n"] = cnt
     return vec
 

--- a/tests/test_sense.py
+++ b/tests/test_sense.py
@@ -1,8 +1,15 @@
 """Pruebas de sense."""
+import time
 import networkx as nx
 import pytest
 
-from tnfr.sense import sigma_vector_node, sigma_vector_from_graph
+from tnfr.sense import (
+    sigma_vector_node,
+    sigma_vector_from_graph,
+    _node_weight,
+    _sigma_from_acc,
+    glyph_unit,
+)
 from tnfr.types import Glyph
 
 
@@ -31,3 +38,41 @@ def test_sigma_vector_from_graph_paths():
     assert sv_si["n"] == 1
     assert sv_epi["n"] == 1
     assert sv_epi["mag"] == pytest.approx(2 * sv_si["mag"])
+
+
+def _sigma_vector_from_graph_naive(G, weight_mode: str = "Si"):
+    """Referencia que recalcula ``glyph_unit(g) * w`` en cada paso."""
+    acc = complex(0.0, 0.0)
+    cnt = 0
+    for n in G.nodes():
+        nw = _node_weight(G, n, weight_mode)
+        if not nw:
+            continue
+        g, w, _ = nw
+        acc += glyph_unit(g) * w
+        cnt += 1
+    vec = _sigma_from_acc(acc, cnt)
+    vec["n"] = cnt
+    return vec
+
+
+def test_sigma_vector_from_graph_matches_naive():
+    """La versión optimizada coincide con el cálculo ingenuo y no es más lenta."""
+    G_opt = nx.Graph()
+    glyphs = list(Glyph)
+    for i in range(1000):
+        g = glyphs[i % len(glyphs)].value
+        G_opt.add_node(i, hist_glifos=[g], Si=float(i % 10) / 10)
+    G_ref = G_opt.copy()
+
+    start = time.perf_counter()
+    vec_opt = sigma_vector_from_graph(G_opt)
+    t_opt = time.perf_counter() - start
+
+    start = time.perf_counter()
+    vec_ref = _sigma_vector_from_graph_naive(G_ref)
+    t_ref = time.perf_counter() - start
+
+    for key in ("x", "y", "mag", "angle", "n"):
+        assert vec_opt[key] == pytest.approx(vec_ref[key])
+    assert t_opt <= t_ref * 2


### PR DESCRIPTION
## Summary
- use precomputed weighted unit vector from `_node_weight` in `sigma_vector_from_graph`
- document `_node_weight` and rename accumulator
- add regression micro-benchmark for `sigma_vector_from_graph`

## Testing
- `pytest tests/test_sense.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5df186c188321b15e70ccc0cca560