### PR TITLE
Cache node neighbors in compute_Si

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -766,6 +766,7 @@ def compute_Si(G, *, inplace: bool = True) -> Dict[Any, float]:
     También guarda en ``G.graph`` los pesos normalizados y la
     sensibilidad parcial (∂Si/∂componente).
     """
+    neighbors = {n: list(G.neighbors(n)) for n in G}
     w = {**DEFAULTS["SI_WEIGHTS"], **G.graph.get("SI_WEIGHTS", {})}
     weights = normalize_weights(w, ("alpha", "beta", "gamma"), default=0.0)
     alpha = weights["alpha"]
@@ -809,7 +810,7 @@ def compute_Si(G, *, inplace: bool = True) -> Dict[Any, float]:
 
         # dispersión de fase local utilizando vecinos precomputados
         th_i = thetas[n]
-        neigh = list(G.neighbors(n))
+        neigh = neighbors[n]
         deg = len(neigh)
         if deg:
             sum_cos = sum(cos_th[v] for v in neigh)


### PR DESCRIPTION
## Summary
- cache node neighbor lists at the start of `compute_Si`
- use the cached neighbor lists when computing phase dispersion

## Testing
- `pytest tests/test_sense.py tests/test_metrics.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5e4e134c8832189e2fd115db045db