### PR TITLE
Add CallbackEvent enum for callback management

### DIFF
--- a/tests/test_observers.py
+++ b/tests/test_observers.py
@@ -9,7 +9,8 @@ from tnfr.observers import sincronía_fase, orden_kuramoto, carga_glifica, wbar
 from tnfr.gamma import kuramoto_R_psi
 from tnfr.sense import sigma_vector
 from tnfr.constants_glifos import ANGLE_MAP, ESTABILIZADORES, DISRUPTIVOS
-from tnfr.helpers import angle_diff, set_attr
+from tnfr.helpers import angle_diff, set_attr, CallbackEvent
+from tnfr.observers import attach_standard_observer
 
 def test_phase_observers_match_manual_calculation(graph_canon):
     G = graph_canon()
@@ -81,3 +82,10 @@ def test_wbar_accepts_deque(graph_canon):
     cs = deque([0.1, 0.5, 0.9], maxlen=10)
     G.graph["history"] = {"C_steps": cs}
     assert wbar(G, window=2) == pytest.approx((0.5 + 0.9) / 2)
+
+
+def test_attach_standard_observer_registers_callbacks(graph_canon):
+    G = graph_canon()
+    attach_standard_observer(G)
+    for ev in CallbackEvent:
+        assert ev in G.graph["callbacks"]

--- a/tests/test_register_callback.py
+++ b/tests/test_register_callback.py
@@ -1,5 +1,5 @@
 """Pruebas de register callback."""
-from tnfr.helpers import register_callback
+from tnfr.helpers import register_callback, CallbackEvent
 
 
 def test_register_callback_replaces_existing(graph_canon):
@@ -12,13 +12,13 @@ def test_register_callback_replaces_existing(graph_canon):
         pass
 
     # initial registration
-    register_callback(G, event="before_step", func=cb1, name="cb")
-    assert G.graph["callbacks"]["before_step"] == [("cb", cb1)]
+    register_callback(G, event=CallbackEvent.BEFORE_STEP, func=cb1, name="cb")
+    assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP] == [("cb", cb1)]
 
     # same name should replace existing
-    register_callback(G, event="before_step", func=cb2, name="cb")
-    assert G.graph["callbacks"]["before_step"] == [("cb", cb2)]
+    register_callback(G, event=CallbackEvent.BEFORE_STEP, func=cb2, name="cb")
+    assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP] == [("cb", cb2)]
 
     # same function with different name should also replace existing
-    register_callback(G, event="before_step", func=cb2, name="other")
-    assert G.graph["callbacks"]["before_step"] == [("other", cb2)]
+    register_callback(G, event=CallbackEvent.BEFORE_STEP, func=cb2, name="other")
+    assert G.graph["callbacks"][CallbackEvent.BEFORE_STEP] == [("other", cb2)]


### PR DESCRIPTION
## Summary
- add `CallbackEvent` enum to centralize callback event names
- update callback helpers to use `CallbackEvent`
- adapt tests to reference the new enum

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5e59c37c08321970f99726a9beb1a