### PR TITLE
Fix get_param default lookup

### DIFF
--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -82,10 +82,9 @@ def get_param(G, key: str):
                 stacklevel=2,
             )
             return G.graph[alias]
-    value = DEFAULTS.get(key)
-    if value is None:
+    if key not in DEFAULTS:
         raise KeyError(f"Parámetro desconocido: '{key}'")
-    return value
+    return DEFAULTS[key]
 
 
 # Alias exportados por conveniencia (evita imports circulares)


### PR DESCRIPTION
## Summary
- ensure get_param checks membership in DEFAULTS instead of None value

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5e87abb688321895cfa3f16f41d20