### PR TITLE
Valida archivo antes de lectura en read_structured_file

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -112,10 +112,14 @@ def read_structured_file(path: Path) -> Any:
     if suffix not in PARSERS:
         raise ValueError(f"Extensión de archivo no soportada: {suffix}")
     parser = PARSERS[suffix]
+    if not path.is_file():
+        raise ValueError(f"El archivo no existe: {path}")
     try:
         text = path.read_text(encoding="utf-8")
-    except (FileNotFoundError, PermissionError) as e:
-        raise ValueError(f"No se pudo abrir {path}: {e}") from e
+    except PermissionError as e:
+        raise ValueError(f"Permiso denegado al leer {path}: {e}") from e
+    except FileNotFoundError as e:  # pragma: no cover - carrera improbable
+        raise ValueError(f"El archivo no existe: {path}") from e
 
     try:
         return parser(text)


### PR DESCRIPTION
## Summary
- Verifica que la ruta exista antes de leer archivos estructurados
- Distingue entre errores por archivo inexistente y permisos insuficientes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5ef57372c832187d107e531257d0c