### PR TITLE
refactor: limit collection materialization

### DIFF
--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -7,7 +7,7 @@ from .constants import (
     ALIAS_SI, ALIAS_DNFR,
     get_param,
 )
-from .helpers import get_attr, clamp01, reciente_glifo, ensure_collection
+from .helpers import get_attr, clamp01, reciente_glifo
 from tnfr.types import Glyph
 
 # Glifos nominales (para evitar typos)
@@ -161,10 +161,9 @@ def on_applied_glifo(G, n, applied: str) -> None:
 def apply_glyph_with_grammar(G, nodes: Optional[Iterable[Any]], glyph: Glyph | str, window: Optional[int] = None) -> None:
     """Aplica ``glyph`` a ``nodes`` pasando por la gramática canónica.
 
-    ``nodes`` admite ``NodeView`` y cualquier iterable. Si no es una
-    :class:`~collections.abc.Collection` (por ejemplo, un generador), se
-    materializa en una ``list`` sólo cuando se requiere indexación del
-    selector.
+    ``nodes`` admite ``NodeView`` y cualquier iterable. Se itera directamente
+    sobre ``nodes`` para evitar materializaciones innecesarias; corresponde al
+    llamador materializarlo si necesita indexación.
     """
 
     from .operators import aplicar_glifo
@@ -173,7 +172,7 @@ def apply_glyph_with_grammar(G, nodes: Optional[Iterable[Any]], glyph: Glyph | s
         window = get_param(G, "GLYPH_HYSTERESIS_WINDOW")
 
     g_str = glyph.value if isinstance(glyph, Glyph) else str(glyph)
-    iter_nodes = ensure_collection(G.nodes() if nodes is None else nodes)
+    iter_nodes = G.nodes() if nodes is None else nodes
     for n in iter_nodes:
         g_eff = enforce_canonical_grammar(G, n, g_str)
         aplicar_glifo(G, n, g_eff, window=window)

--- a/src/tnfr/program.py
+++ b/src/tnfr/program.py
@@ -7,7 +7,6 @@ from collections import deque
 
 from .constants import get_param
 from .grammar import apply_glyph_with_grammar
-from .helpers import ensure_collection
 from .sense import GLYPHS_CANONICAL_SET
 from .types import Glyph
 
@@ -91,14 +90,14 @@ def _all_nodes(G):
 def _apply_glyph_to_targets(G, g: Glyph | str, nodes: Optional[Iterable[Node]] = None):
     """Apply ``g`` to ``nodes`` (or all nodes) respecting the grammar.
 
-    ``nodes`` may be any iterable of nodes, including a ``NodeView`` or
-    other :class:`~collections.abc.Collection`. Non-collection iterables
-    are materialised as a ``list`` only when the active selector requires
-    index-based access.
+    ``nodes`` may be any iterable of nodes, including a ``NodeView`` or other
+    iterables. Para evitar materializaciones innecesarias, se itera sobre el
+    iterable tal cual; corresponde al llamador materializarlo si necesita
+    indexación.
     """
-    nodes = ensure_collection(_all_nodes(G) if nodes is None else nodes)
+    nodes_iter = _all_nodes(G) if nodes is None else nodes
     w = _window(G)
-    apply_glyph_with_grammar(G, nodes, g, w)
+    apply_glyph_with_grammar(G, nodes_iter, g, w)
 
 def _advance(G, step_fn: Optional[AdvanceFn] = None):
     if step_fn is None:
@@ -180,7 +179,7 @@ def play(G, sequence: Sequence[Token], step_fn: Optional[AdvanceFn] = None) -> N
     for op, payload in ops:
         if op == "TARGET":
             nodes_src = _all_nodes(G) if payload.nodes is None else payload.nodes
-            curr_target = list(ensure_collection(nodes_src))
+            curr_target = tuple(nodes_src)
             trace.append({"t": float(G.graph.get("_t", 0.0)), "op": "TARGET", "n": len(curr_target)})
             continue
         if op == "WAIT":

--- a/tests/test_ensure_collection.py
+++ b/tests/test_ensure_collection.py
@@ -3,17 +3,23 @@ from tnfr.helpers import ensure_collection
 
 
 def test_wraps_string():
-    assert ensure_collection("node") == ["node"]
+    assert ensure_collection("node") == ("node",)
 
 
 def test_wraps_bytes():
     data = b"node"
-    assert ensure_collection(data) == [data]
+    assert ensure_collection(data) == (data,)
 
 
 def test_wraps_bytearray():
     arr = bytearray(b"node")
-    assert ensure_collection(arr) == [arr]
+    assert ensure_collection(arr) == (arr,)
+
+
+def test_max_materialize_limit():
+    gen = (i for i in range(5))
+    with pytest.raises(ValueError):
+        ensure_collection(gen, max_materialize=3)
 
 
 def test_non_iterable_error():


### PR DESCRIPTION
## Summary
- add optional `max_materialize` to `ensure_collection` and document memory cost
- avoid list materialization in grammar/program helpers and freeze targets as tuples
- test tuple-based wrapping and materialization guard

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5f0356da88321b534c57324f33091