### PR TITLE
refactor: remove unused acc_lo in glyph selector

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -799,7 +799,7 @@ def parametric_glyph_selector(G, n) -> str:
     thr = _selector_thresholds(G)
     si_hi, si_lo = thr["si_hi"], thr["si_lo"]
     dnfr_hi, dnfr_lo = thr["dnfr_hi"], thr["dnfr_lo"]
-    acc_hi, acc_lo = thr["accel_hi"], thr["accel_lo"]
+    acc_hi = thr["accel_hi"]
     margin = float(G.graph.get("GLYPH_SELECTOR_MARGIN", DEFAULTS["GLYPH_SELECTOR_MARGIN"]))
 
     # Normalizadores por paso


### PR DESCRIPTION
## Summary
- remove unused `acc_lo` variable from `parametric_glyph_selector`

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5f51c46248321ba50647f9e919570