### PR TITLE
chore: remove unused imports

### DIFF
--- a/src/tnfr/selector.py
+++ b/src/tnfr/selector.py
@@ -5,8 +5,8 @@ from typing import Any, Dict
 
 import networkx as nx
 
-from .constants import DEFAULTS, ALIAS_DNFR, ALIAS_D2EPI
-from .helpers import clamp01, get_attr, compute_dnfr_accel_max
+from .constants import DEFAULTS
+from .helpers import clamp01, compute_dnfr_accel_max
 
 
 HYSTERESIS_GLYPHS = ("IL", "OZ", "ZHIR", "THOL", "NAV", "RA")


### PR DESCRIPTION
## Summary
- drop unused alias constants and helper from selector imports

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5f5ef1e48832183bdb2321aad5ca0