### PR TITLE
refactor: drop unused typing imports in export

### DIFF
--- a/src/tnfr/metrics/export.py
+++ b/src/tnfr/metrics/export.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import csv
 import json
-from typing import Dict, List
 
 from ..helpers import ensure_history, ensure_parent
 from ..constants_glifos import GLYPHS_CANONICAL


### PR DESCRIPTION
## Summary
- drop unused `Dict` and `List` imports from metrics exporter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b5f869aa108321ae139136f288dc96