### PR TITLE
chore: remove Dict import

### DIFF
--- a/src/tnfr/metrics/diagnosis.py
+++ b/src/tnfr/metrics/diagnosis.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 from statistics import fmean
-from typing import Dict
 
 from ..constants import ALIAS_EPI, ALIAS_VF, ALIAS_DNFR, ALIAS_SI, DIAGNOSIS, COHERENCE
 from ..helpers import (


### PR DESCRIPTION
## Summary
- remove unused Dict import from diagnosis metrics

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'tnfr')*


------
https://chatgpt.com/codex/tasks/task_e_68b5f9b6614c83219d0eae631ccdd9b6