### PR TITLE
chore: remove unused logging import from normalize weights test

### DIFF
--- a/tests/test_normalize_weights.py
+++ b/tests/test_normalize_weights.py
@@ -1,5 +1,4 @@
 """Tests for normalize_weights helper."""
-import logging
 import math
 import pytest
 from tnfr.helpers import normalize_weights


### PR DESCRIPTION
## Summary
- remove unused `logging` import from `tests/test_normalize_weights.py`

## Testing
- `pytest tests/test_normalize_weights.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5fa6f629c8321ac34ca83587f9cfe