### PR TITLE
refactor: normalize imports and utilities

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -10,8 +10,6 @@ from collections import deque
 
 import networkx as nx
 
-logger = logging.getLogger(__name__)
-
 from .constants import inject_defaults, DEFAULTS, METRIC_DEFAULTS
 from .sense import register_sigma_callback, sigma_rose
 from .metrics import (
@@ -33,6 +31,8 @@ from .config import apply_config
 from .helpers import read_structured_file, list_mean, ensure_parent
 from .observers import attach_standard_observer
 from . import __version__
+
+logger = logging.getLogger(__name__)
 
 
 def _parse_tokens(obj: Any) -> List[Any]:

--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -1,45 +1,13 @@
 """Dinámica del sistema."""
 from __future__ import annotations
-from typing import Dict, Any, Literal
+
+import logging
 import math
 import random
 from collections import deque, OrderedDict
-import logging
+from typing import Dict, Any, Literal
 
 import networkx as nx
-
-logger = logging.getLogger(__name__)
-
-# ``numpy`` is an optional dependency.  It is loaded lazily to avoid emitting
-# warnings when the vectorized path is not used.
-np: Any | None = None
-
-def _ensure_numpy(*, warn: bool = False) -> bool:
-    """Load ``numpy`` on demand.
-
-    Parameters
-    ----------
-    warn:
-        If ``True`` the failure to import ``numpy`` is logged as a warning,
-        otherwise a debug message is emitted. Returns ``True`` if ``numpy``
-        was imported successfully.
-    """
-
-    global np
-    if np is not None:  # pragma: no cover - already loaded
-        return True
-    try:  # Optional dependency
-        import numpy as _np  # type: ignore
-    except ImportError:  # pragma: no cover - handled gracefully
-        log = logger.warning if warn else logger.debug
-        log(
-            "Fallo al importar numpy, se continuará con el modo no vectorizado",
-            exc_info=True,
-        )
-        np = None
-        return False
-    np = _np
-    return True
 
 from .observers import sincronía_fase, carga_glifica, orden_kuramoto
 from .sense import sigma_vector
@@ -75,6 +43,39 @@ from .selector import (
     _calc_selector_score,
     _apply_selector_hysteresis,
 )
+
+logger = logging.getLogger(__name__)
+
+# ``numpy`` is an optional dependency.  It is loaded lazily to avoid emitting
+# warnings when the vectorized path is not used.
+np: Any | None = None
+
+def _ensure_numpy(*, warn: bool = False) -> bool:
+    """Load ``numpy`` on demand.
+
+    Parameters
+    ----------
+    warn:
+        If ``True`` the failure to import ``numpy`` is logged as a warning,
+        otherwise a debug message is emitted. Returns ``True`` if ``numpy``
+        was imported successfully.
+    """
+
+    global np
+    if np is not None:  # pragma: no cover - already loaded
+        return True
+    try:  # Optional dependency
+        import numpy as _np  # type: ignore
+    except ImportError:  # pragma: no cover - handled gracefully
+        log = logger.warning if warn else logger.debug
+        log(
+            "Fallo al importar numpy, se continuará con el modo no vectorizado",
+            exc_info=True,
+        )
+        np = None
+        return False
+    np = _np
+    return True
 
 # Cacheo de nodos y matriz de adyacencia asociado a cada grafo
 def _cached_nodes_and_A(

--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -8,7 +8,7 @@ from .constants import (
     get_param,
 )
 from .helpers import get_attr, clamp01, reciente_glifo
-from tnfr.types import Glyph
+from .types import Glyph
 
 # Glifos nominales (para evitar typos)
 AL = Glyph.AL

--- a/src/tnfr/initialization.py
+++ b/src/tnfr/initialization.py
@@ -53,8 +53,8 @@ def init_node_attrs(G: nx.Graph, *, override: bool = True) -> nx.Graph:
     si_max = float(G.graph.get("INIT_SI_MAX", 0.7))
     epi_val = float(G.graph.get("INIT_EPI_VALUE", 0.0))
 
-    for idx, n in enumerate(G.nodes()):
-        rng_node = random.Random(seed + idx)
+    rng = random.Random(seed)
+    for n in G.nodes():
         nd = G.nodes[n]
 
         if override or "EPI" not in nd:
@@ -62,7 +62,7 @@ def init_node_attrs(G: nx.Graph, *, override: bool = True) -> nx.Graph:
 
         if init_rand_phase:
             if override or "θ" not in nd:
-                nd["θ"] = rng_node.uniform(th_min, th_max)
+                nd["θ"] = rng.uniform(th_min, th_max)
         else:
             if override:
                 nd["θ"] = 0.0
@@ -70,16 +70,16 @@ def init_node_attrs(G: nx.Graph, *, override: bool = True) -> nx.Graph:
                 nd.setdefault("θ", 0.0)
 
         if vf_mode == "uniform":
-            vf = rng_node.uniform(float(vf_uniform_min), float(vf_uniform_max))
+            vf = rng.uniform(float(vf_uniform_min), float(vf_uniform_max))
         elif vf_mode == "normal":
             for _ in range(16):
-                cand = rng_node.normalvariate(vf_mean, vf_std)
+                cand = rng.normalvariate(vf_mean, vf_std)
                 if vf_min_lim <= cand <= vf_max_lim:
                     vf = cand
                     break
             else:
                 vf = min(
-                    max(rng_node.normalvariate(vf_mean, vf_std), vf_min_lim),
+                    max(rng.normalvariate(vf_mean, vf_std), vf_min_lim),
                     vf_max_lim,
                 )
         else:
@@ -89,7 +89,7 @@ def init_node_attrs(G: nx.Graph, *, override: bool = True) -> nx.Graph:
         if override or "νf" not in nd:
             nd["νf"] = float(vf)
 
-        si = rng_node.uniform(si_min, si_max)
+        si = rng.uniform(si_min, si_max)
         if override or "Si" not in nd:
             nd["Si"] = float(si)
 

--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -1,10 +1,9 @@
 """Registro de trazas."""
 from __future__ import annotations
-from collections import Counter
 from typing import Any, Callable, Dict, List, Optional
 
 from .constants import TRACE
-from .helpers import register_callback, ensure_history, last_glifo
+from .helpers import register_callback, ensure_history, count_glyphs
 
 try:
     from .gamma import kuramoto_R_psi
@@ -162,11 +161,7 @@ def _trace_after(G, *args, **kwargs):
         }
 
     def glifo_counts_field(G):
-        cnt = Counter()
-        for n in G.nodes():
-            g = last_glifo(G.nodes[n])
-            if g:
-                cnt[g] += 1
+        cnt = count_glyphs(G, window=1)
         return {"glifos": dict(cnt)}
 
     fields = {


### PR DESCRIPTION
## Summary
- reorder CLI imports to avoid E402 and keep logger after imports
- unify dynamics imports and move logger below for consistent style
- use relative package paths and shared RNG/helpers for lighter runtime

## Testing
- `pip install -e .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5fb62e5408321b8450b6e648fc42d