### PR TITLE
Refactor grammar enforcement into modular checks

### DIFF
--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -48,6 +48,33 @@ def test_thol_closure(graph_canon):
     assert enforce_canonical_grammar(G, 0, EN) == SHA
 
 
+def test_repeat_window_and_force(graph_canon):
+    G = graph_canon()
+    G.add_node(0)
+    attach_defaults(G)
+    nd = G.nodes[0]
+    nd['hist_glifos'] = deque([ZHIR.value, 'OZ'])
+    G.graph['GRAMMAR'] = {
+        'window': 3,
+        'avoid_repeats': ['ZHIR'],
+        'force_dnfr': 0.5,
+        'force_accel': 0.8,
+        'fallbacks': {'ZHIR': 'NAV'},
+    }
+    G.graph['_sel_norms'] = {'dnfr_max': 1.0, 'accel_max': 1.0}
+
+    nd['ΔNFR'] = 0.0
+    nd['d2EPI_dt2'] = 0.0
+    assert enforce_canonical_grammar(G, 0, ZHIR) == NAV
+
+    nd['ΔNFR'] = 0.6
+    assert enforce_canonical_grammar(G, 0, ZHIR) == ZHIR
+
+    nd['ΔNFR'] = 0.0
+    nd['d2EPI_dt2'] = 0.9
+    assert enforce_canonical_grammar(G, 0, ZHIR) == ZHIR
+
+
 def test_lag_counters_enforced(graph_canon):
     G = graph_canon()
     G.add_node(0)


### PR DESCRIPTION
## Summary
- break down canonical grammar enforcement into discrete checks
- add DNFR and acceleration repeat guards
- test repeat window and force thresholds

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b68f0f4a6c832182191229e7b7e957