### PR TITLE
Convert mapping proxies to dict before combining defaults

### DIFF
--- a/src/tnfr/constants/__init__.py
+++ b/src/tnfr/constants/__init__.py
@@ -20,7 +20,12 @@ from .metric import (
 
 # Diccionario combinado exportado
 DEFAULTS: Dict[str, Any] = dict(
-    ChainMap(METRIC_DEFAULTS, REMESH_DEFAULTS, INIT_DEFAULTS, CORE_DEFAULTS)
+    ChainMap(
+        dict(METRIC_DEFAULTS),
+        dict(REMESH_DEFAULTS),
+        dict(INIT_DEFAULTS),
+        dict(CORE_DEFAULTS),
+    )
 )
 
 # -------------------------


### PR DESCRIPTION
## Summary
- ensure MappingProxyType defaults are converted to dict before combining with `ChainMap`

## Testing
- `pyright src/tnfr/constants/__init__.py`
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b69a245e188321b83cdcd2ae75fd27