### PR TITLE
Add default materialization limit to ensure_collection

### DIFF
--- a/tests/test_ensure_collection.py
+++ b/tests/test_ensure_collection.py
@@ -22,6 +22,18 @@ def test_max_materialize_limit():
         ensure_collection(gen, max_materialize=3)
 
 
+def test_default_limit_enforced():
+    gen = (i for i in range(1001))
+    with pytest.raises(ValueError):
+        ensure_collection(gen)
+
+
+def test_none_uses_default_limit():
+    gen = (i for i in range(1001))
+    with pytest.raises(ValueError):
+        ensure_collection(gen, max_materialize=None)
+
+
 def test_non_iterable_error():
     with pytest.raises(TypeError):
         ensure_collection(42)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- set a default max_materialize of 1000 in `ensure_collection`
- guard materialization beyond the default even when no explicit limit is given
- add tests covering default limit behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6a17393d08321b363d1b67ecc544a