### PR TITLE
Warn on unknown GAMMA type

### DIFF
--- a/tests/test_gamma.py
+++ b/tests/test_gamma.py
@@ -107,3 +107,19 @@ def test_eval_gamma_logs_and_strict_mode(graph_canon, caplog):
 
     with pytest.raises(ValueError):
         eval_gamma(G, 0, t=0.0, strict=True)
+
+
+def test_eval_gamma_unknown_type_warning_and_strict(graph_canon, caplog):
+    G = graph_canon()
+    G.add_nodes_from([0])
+    attach_defaults(G)
+    merge_overrides(G, GAMMA={"type": "unknown_type"})
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING):
+        g = eval_gamma(G, 0, t=0.0)
+    assert g == 0.0
+    assert any("Tipo GAMMA desconocido" in rec.message for rec in caplog.records)
+
+    with pytest.raises(ValueError):
+        eval_gamma(G, 0, t=0.0, strict=True)


### PR DESCRIPTION
## Summary
- log warning or raise ValueError when GAMMA type is unknown
- document unknown GAMMA handling
- test warning and strict mode for unknown GAMMA types

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6a5c7029883219c8c4ab7c73aeb09