### PR TITLE
Implement bounded jitter RNG cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ has fewer than **50 nodes**, in which case all nodes are included.
 ### Jitter RNG cache
 
 `random_jitter` uses an LRU cache of `random.Random` instances keyed by `(seed, node)`.
-`JITTER_CACHE_SIZE` controls the maximum number of cached generators (default: `256`).
-Increase it for large graphs or heavy jitter usage, or lower it to save memory.
+`JITTER_CACHE_SIZE` controls the maximum number of cached generators (default: `256`);
+when the limit is exceeded the least‑recently used entry is discarded. Increase it for
+large graphs or heavy jitter usage, or lower it to save memory.
 
 ---
 

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -53,6 +53,31 @@ def test_random_jitter_negative_amplitude(graph_canon):
         random_jitter(n0, -0.1)
 
 
+def test_rng_cache_lru_purge(graph_canon):
+    clear_rng_cache()
+    G = graph_canon()
+    G.graph["JITTER_CACHE_SIZE"] = 2
+    G.add_nodes_from(range(3))
+    n0, n1, n2 = [NodoNX(G, i) for i in range(3)]
+
+    j0 = random_jitter(n0, 0.5)
+    j1 = random_jitter(n1, 0.5)
+    j2 = random_jitter(n2, 0.5)
+
+    j1b = random_jitter(n1, 0.5)
+    assert j1b != j1
+
+    j0b = random_jitter(n0, 0.5)
+    assert j0b == j0
+
+    cache = operators._rng_cache[G]
+    seed = int(G.graph.get("RANDOM_SEED", 0))
+    p0 = (seed, operators._node_offset(G, 0))
+    p1 = (seed, operators._node_offset(G, 1))
+    p2 = (seed, operators._node_offset(G, 2))
+    assert p0 in cache and p1 in cache and p2 not in cache
+
+
 def test_rng_cache_expires_after_graph_gc(graph_canon):
     import gc
 


### PR DESCRIPTION
## Summary
- Limit jitter RNG cache using configurable `JITTER_CACHE_SIZE`
- Evict least recently used RNG when cache exceeds limit
- Document jitter cache limit and test LRU purge

## Testing
- `PYTHONPATH=src python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6a7ea11108321a4cd590bac376b04