### PR TITLE
Skip RNG cache when size nonpositive

### DIFF
--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -87,8 +87,11 @@ def _get_rng(scope: object, seed: int, key: int, size: int) -> random.Random:
     """Return cached ``random.Random`` for ``(seed, key)`` scoped to ``scope``.
 
     The cache for each ``scope`` is bounded by ``size`` and follows an LRU
-    eviction policy.
+    eviction policy.  When ``size`` is non-positive, caching is skipped and a
+    fresh generator is returned on every call.
     """
+    if int(size) <= 0:
+        return _jitter_base(seed, key)
     cache = _rng_cache.setdefault(scope, OrderedDict())
     pair = (int(seed), int(key))
     rng = cache.get(pair)
@@ -132,9 +135,10 @@ def random_jitter(
     references to nodes. By default a global cache of ``(seed, key) → random.Random``
     instances, scoped by graph via weak references, advances deterministic
     sequences across calls. The cache obeys the ``JITTER_CACHE_SIZE`` parameter
-    and evicts the least recently used generator when the limit is exceeded.
-    When ``cache`` is provided, it is used instead and must handle its own
-    purging policy.
+    and evicts the least recently used generator when the limit is exceeded.  When
+    the parameter is ``0`` or negative, the cache is bypassed and a new generator
+    is created on each call. When ``cache`` is provided, it is used instead and
+    must handle its own purging policy.
     """
 
     if amplitude <= 0:

--- a/tests/test_operators.py
+++ b/tests/test_operators.py
@@ -53,6 +53,18 @@ def test_random_jitter_negative_amplitude(graph_canon):
         random_jitter(n0, -0.1)
 
 
+def test_rng_cache_disabled_with_size_zero(graph_canon):
+    clear_rng_cache()
+    G = graph_canon()
+    G.graph["JITTER_CACHE_SIZE"] = 0
+    G.add_node(0)
+    n0 = NodoNX(G, 0)
+    j1 = random_jitter(n0, 0.5)
+    j2 = random_jitter(n0, 0.5)
+    assert j1 == j2
+    assert len(operators._rng_cache) == 0
+
+
 def test_rng_cache_lru_purge(graph_canon):
     clear_rng_cache()
     G = graph_canon()


### PR DESCRIPTION
## Summary
- Avoid storing RNGs in `_get_rng` when cache size is non-positive
- Document cache-bypass behaviour for zero cache size in `random_jitter`
- Test RNG cache is skipped when `JITTER_CACHE_SIZE` is 0

## Testing
- `PYTHONPATH=src pytest tests/test_operators.py::test_rng_cache_disabled_with_size_zero -q`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6b2f830bc83219b5f94bd5e48f63a