### PR TITLE
Cache node indices per graph and add independence test

### DIFF
--- a/src/tnfr/metrics/coherence.py
+++ b/src/tnfr/metrics/coherence.py
@@ -192,14 +192,15 @@ def local_phase_sync_weighted(G, n, nodes_order=None, W_row=None, node_to_index=
 
     # --- Mapeo nodo → índice ---
     if node_to_index is None:
-        cache_nodes = getattr(local_phase_sync_weighted, "_cache_nodes", None)
-        cache_map = getattr(local_phase_sync_weighted, "_cache_map", None)
-        if cache_nodes is not nodes_order:
+        cache_key = "_lpsw_cache"
+        cache = G.graph.get(cache_key, {})
+        nodes_tuple = tuple(nodes_order)
+        nodes_set = frozenset(G.nodes())
+        if cache.get("nodes") != nodes_tuple or cache.get("set") != nodes_set:
             node_to_index = {v: i for i, v in enumerate(nodes_order)}
-            local_phase_sync_weighted._cache_nodes = nodes_order
-            local_phase_sync_weighted._cache_map = node_to_index
+            G.graph[cache_key] = {"nodes": nodes_tuple, "set": nodes_set, "map": node_to_index}
         else:
-            node_to_index = cache_map
+            node_to_index = cache.get("map", {})
 
     i = node_to_index.get(n, None)
     if i is None:

--- a/tests/test_coherence_cache.py
+++ b/tests/test_coherence_cache.py
@@ -1,0 +1,37 @@
+import pytest
+import networkx as nx
+
+from tnfr.constants import ALIAS_THETA
+from tnfr.metrics import coherence_matrix, local_phase_sync_weighted
+
+
+def make_graph(offset=0):
+    G = nx.Graph()
+    G.add_node(offset)
+    G.add_node(offset + 1)
+    G.add_edge(offset, offset + 1)
+    G.nodes[offset][ALIAS_THETA[0]] = 0.0
+    G.nodes[offset + 1][ALIAS_THETA[0]] = 0.0
+    return G
+
+
+def test_local_phase_sync_independent_graphs():
+    G1 = make_graph(0)
+    G2 = make_graph(10)
+
+    nodes1, W1 = coherence_matrix(G1)
+    nodes2, W2 = coherence_matrix(G2)
+
+    r1 = local_phase_sync_weighted(G1, nodes1[0], nodes_order=nodes1, W_row=W1)
+    r2 = local_phase_sync_weighted(G2, nodes2[0], nodes_order=nodes2, W_row=W2)
+
+    assert r1 == pytest.approx(1.0)
+    assert r2 == pytest.approx(1.0)
+
+    key = "_lpsw_cache"
+    assert G1.graph[key]["nodes"] == tuple(nodes1)
+    assert G2.graph[key]["nodes"] == tuple(nodes2)
+    assert G1.graph[key] is not G2.graph[key]
+
+    r1_again = local_phase_sync_weighted(G1, nodes1[0], nodes_order=nodes1, W_row=W1)
+    assert r1_again == pytest.approx(r1)


### PR DESCRIPTION
## Summary
- store local_phase_sync_weighted node→index cache in `G.graph`
- invalidate cache when graph node set changes
- add regression test covering cache independence across graphs

## Testing
- `PYTHONPATH=src python -m pytest tests/test_coherence_cache.py -q`
- `PYTHONPATH=src python -m pytest tests/test_metrics.py::test_pp_val_zero_when_no_remesh -q`


------
https://chatgpt.com/codex/tasks/task_e_68b6b655c0f48321a788895a412abce6