### PR TITLE
Cache NodoNX instances and expose neighbor ids

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -619,8 +619,9 @@ def fase_media(obj, n=None) -> float:
     segundo caso se envuelve en :class:`NodoNX` para reutilizar la misma lógica.
     """
 
+    from .node import NodoNX  # importación local para evitar ciclo
+
     if n is not None:
-        from .node import NodoNX  # importación local para evitar ciclo
         node = NodoNX(obj, n)
     else:
         node = obj  # se asume NodoProtocol
@@ -628,7 +629,10 @@ def fase_media(obj, n=None) -> float:
     x = y = 0.0
     count = 0
     for v in node.neighbors():
-        th = getattr(v, "theta", 0.0)
+        if hasattr(v, "theta"):
+            th = getattr(v, "theta", 0.0)
+        else:
+            th = NodoNX.from_graph(node.G, v).theta  # type: ignore[attr-defined]
         x += math.cos(th)
         y += math.sin(th)
         count += 1

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -209,10 +209,18 @@ def _mix_epi_with_neighbors(
         default_glyph.value if isinstance(default_glyph, Glyph) else str(default_glyph)
     )
     epi = node.EPI
-    neigh = list(node.neighbors())
-    if not neigh:
+    neigh_ids = list(node.neighbors())
+    if not neigh_ids:
         node.epi_kind = default_kind
         return
+    if hasattr(node, "G"):
+        NodoNX = _get_NodoNX()
+        neigh = [
+            v if hasattr(v, "EPI") else NodoNX.from_graph(node.G, v)  # type: ignore[attr-defined]
+            for v in neigh_ids
+        ]
+    else:
+        neigh = neigh_ids  # NodoTNFR already
     epi_bar = list_mean(v.EPI for v in neigh)
     node.EPI = (1 - mix) * epi + mix * epi_bar
     node.epi_kind = _select_dominant_glifo(node, neigh) or default_kind
@@ -283,7 +291,7 @@ def _op_UM(node: NodoProtocol) -> None:  # UM — Acoplamiento
         sample_ids = node.graph.get("_node_sample")
         if sample_ids is not None and hasattr(node, "G"):
             NodoNX = _get_NodoNX()
-            iter_nodes = (NodoNX(node.G, j) for j in sample_ids)
+            iter_nodes = (NodoNX.from_graph(node.G, j) for j in sample_ids)
         else:
             iter_nodes = node.all_nodes()
 


### PR DESCRIPTION
## Summary
- cache NodoNX objects on the graph and have `neighbors` yield node identifiers
- resolve neighbor identifiers via cache in `fase_media`
- adapt glyph mixing logic to the new neighbor format

## Testing
- `PYTHONPATH=src pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b6b8ab8adc8321a40a53e0115e27f5