### PR TITLE
Restrict Glyph fallback exceptions

### DIFF
--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 from typing import Dict, Any, Set, Iterable, Optional, Callable
+import logging
 
 from .constants import (
     DEFAULTS,
@@ -12,6 +13,8 @@ from .constants import (
 )
 from .helpers import get_attr, clamp01, reciente_glifo
 from .types import Glyph
+
+logger = logging.getLogger(__name__)
 
 # Glifos nominales (para evitar typos)
 AL = Glyph.AL
@@ -133,10 +136,12 @@ def _check_repeats(G, n, cand: str, cfg: Dict[str, Any]) -> str:
         fb = fallbacks.get(cand_key, CANON_FALLBACK.get(cand_key, cand_key))
         try:
             return Glyph(fb)
-        except Exception:
+        except (ValueError, TypeError):
             return fb
+        except Exception:
+            logger.debug("Unexpected exception constructing glyph from %r", fb, exc_info=True)
+            raise
     return cand
-
 
 def _check_force(
     G,

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -75,6 +75,36 @@ def test_repeat_window_and_force(graph_canon):
     assert enforce_canonical_grammar(G, 0, ZHIR) == ZHIR
 
 
+
+
+def test_repeat_invalid_fallback_string(graph_canon):
+    G = graph_canon()
+    G.add_node(0)
+    attach_defaults(G)
+    nd = G.nodes[0]
+    nd['hist_glifos'] = deque([ZHIR.value])
+    G.graph['GRAMMAR'] = {
+        'window': 3,
+        'avoid_repeats': ['ZHIR'],
+        'fallbacks': {'ZHIR': 'NOPE'},
+    }
+    assert enforce_canonical_grammar(G, 0, ZHIR) == IL
+
+
+def test_repeat_invalid_fallback_type(graph_canon):
+    G = graph_canon()
+    G.add_node(0)
+    attach_defaults(G)
+    nd = G.nodes[0]
+    nd['hist_glifos'] = deque([ZHIR.value])
+    obj = object()
+    G.graph['GRAMMAR'] = {
+        'window': 3,
+        'avoid_repeats': ['ZHIR'],
+        'fallbacks': {'ZHIR': obj},
+    }
+    assert enforce_canonical_grammar(G, 0, ZHIR) == IL
+
 def test_lag_counters_enforced(graph_canon):
     G = graph_canon()
     G.add_node(0)


### PR DESCRIPTION
## Summary
- narrow glyph construction fallback to catch only `ValueError` and `TypeError`
- log unexpected glyph fallback errors at debug level for visibility
- test invalid fallback strings and objects to ensure canonical fallback is applied

## Testing
- `pytest tests/test_grammar.py::test_repeat_invalid_fallback_string tests/test_grammar.py::test_repeat_invalid_fallback_type -q`
- `pytest tests/test_grammar.py::test_repeat_window_and_force -q`


------
https://chatgpt.com/codex/tasks/task_e_68b703af8828832191d43cbfb30c7d15