### PR TITLE
Simplify glyph validation using node data

### DIFF
--- a/src/tnfr/validators.py
+++ b/src/tnfr/validators.py
@@ -28,8 +28,8 @@ def _validate_sigma(G) -> None:
 
 
 def _validate_glifos(G) -> None:
-    for n in G.nodes():
-        g = last_glifo(G.nodes[n])
+    for n, data in G.nodes(data=True):
+        g = last_glifo(data)
         if g and g not in GLYPHS_CANONICAL_SET:
             raise ValueError(f"Glifo inválido {g} en nodo {n}")
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -53,6 +53,11 @@ def test_validator_glifo_invalido():
         run_validators(G)
 
 
+def test_validator_glifo_valido():
+    G = _base_graph()
+    run_validators(G)
+
+
 def test_read_structured_file_json(tmp_path):
     path = tmp_path / "cfg.json"
     path.write_text("{\"x\": 1}", encoding="utf-8")


### PR DESCRIPTION
## Summary
- Iterate over nodes with `G.nodes(data=True)` in glyph validator to avoid extra indexing
- Add test ensuring validators pass with valid glyph data

## Testing
- `PYTHONPATH=src pytest tests/test_validators.py`


------
https://chatgpt.com/codex/tasks/task_e_68b70813ae248321ad70e3e647ecdb1a