### PR TITLE
Normalize weight before graph type branch

### DIFF
--- a/src/tnfr/node.py
+++ b/src/tnfr/node.py
@@ -94,22 +94,20 @@ def _add_edge_common(G, n1, n2, weight, overwrite):
     if n1 == n2:
         return
 
+    weight = float(weight)
+    if weight < 0:
+        raise ValueError("Edge weight must be non-negative")
+
     if hasattr(G, "has_edge"):
         # networkx graph
         if G.has_edge(n1, n2) and not overwrite:
             return
-        weight = float(weight)
-        if weight < 0:
-            raise ValueError("Edge weight must be non-negative")
         G.add_edge(n1, n2, weight=weight)
         increment_edge_version(G)
     else:
         # NodoTNFR-style graph
         if n2 in n1._neighbors and not overwrite:
             return
-        weight = float(weight)
-        if weight < 0:
-            raise ValueError("Edge weight must be non-negative")
         n1._neighbors[n2] = weight
         n2._neighbors[n1] = weight
         increment_edge_version(G)

--- a/tests/test_node_weights.py
+++ b/tests/test_node_weights.py
@@ -58,3 +58,25 @@ def test_add_edge_rejects_negative_weight_nx():
     with pytest.raises(ValueError):
         a.add_edge(b, weight=-0.5)
     assert not a.has_edge(b)
+
+
+def test_add_edge_rejects_negative_weight_existing_edge():
+    a = NodoTNFR()
+    b = NodoTNFR()
+    a.add_edge(b, weight=1.0)
+    with pytest.raises(ValueError):
+        a.add_edge(b, weight=-2.0)
+    assert math.isclose(a.edge_weight(b), 1.0)
+    assert math.isclose(b.edge_weight(a), 1.0)
+
+
+def test_add_edge_rejects_negative_weight_existing_edge_nx():
+    G = nx.Graph()
+    G.add_node(0)
+    G.add_node(1)
+    a = NodoNX(G, 0)
+    b = NodoNX(G, 1)
+    a.add_edge(b, weight=1.0)
+    with pytest.raises(ValueError):
+        a.add_edge(b, weight=-2.0)
+    assert math.isclose(G[0][1]["weight"], 1.0)


### PR DESCRIPTION
## Summary
- Consolidate edge weight normalization and validation in `_add_edge_common`
- Ensure negative weights are rejected even when an edge exists
- Add regression tests for negative weights on TNFR and networkx graphs

## Testing
- `PYTHONPATH=src pytest tests/test_node_weights.py -q`
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b708c842708321b4cb3dd8d9ebdf2f