### PR TITLE
Ensure collection limit check uses sentinel element

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -197,8 +197,9 @@ def ensure_collection(
         limit = (
             MAX_MATERIALIZE_DEFAULT if max_materialize is None else max_materialize
         )
-        data = tuple(islice(it, limit + 1))
-        if len(data) > limit:
+        data = tuple(islice(it, limit))
+        extra = next(it, None)
+        if extra is not None:
             raise ValueError(
                 f"Iterable materialization exceeded {limit} items"
             )

--- a/tests/test_ensure_collection.py
+++ b/tests/test_ensure_collection.py
@@ -22,6 +22,11 @@ def test_max_materialize_limit():
         ensure_collection(gen, max_materialize=3)
 
 
+def test_materialization_at_limit_allowed():
+    gen = (i for i in range(3))
+    assert ensure_collection(gen, max_materialize=3) == (0, 1, 2)
+
+
 def test_negative_max_materialize_error():
     gen = (i for i in range(5))
     with pytest.raises(ValueError):


### PR DESCRIPTION
## Summary
- Avoid over-materializing in `ensure_collection` by slicing only up to the limit and checking one extra element
- Error if iterable produces more items than allowed
- Test that exact-limit materialization succeeds

## Testing
- `PYTHONPATH=src pytest -q` *(fails: test_update_tg_performance::test_update_tg_matches_naive)*
- `PYTHONPATH=src pytest tests/test_ensure_collection.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7112162fc832193752ad1c84100da