### PR TITLE
Handle non-dict trace fields

### DIFF
--- a/src/tnfr/trace.py
+++ b/src/tnfr/trace.py
@@ -1,6 +1,7 @@
 """Registro de trazas."""
 from __future__ import annotations
 from typing import Any, Callable, Dict, List, Optional, Protocol
+import warnings
 
 
 class _KuramotoFn(Protocol):
@@ -125,11 +126,29 @@ def _trace_capture(
 
 
 def gamma_field(G):
-    return {"gamma": dict(G.graph.get("GAMMA", {}))}
+    gam = G.graph.get("GAMMA", {})
+    if not isinstance(gam, dict):
+        if gam is not None:
+            warnings.warn(
+                "G.graph['GAMMA'] no es un mapeo; se ignora",
+                UserWarning,
+                stacklevel=2,
+            )
+        return {}
+    return {"gamma": dict(gam)}
 
 
 def grammar_field(G):
-    return {"grammar": dict(G.graph.get("GRAMMAR_CANON", {}))}
+    gram = G.graph.get("GRAMMAR_CANON", {})
+    if not isinstance(gram, dict):
+        if gram is not None:
+            warnings.warn(
+                "G.graph['GRAMMAR_CANON'] no es un mapeo; se ignora",
+                UserWarning,
+                stacklevel=2,
+            )
+        return {}
+    return {"grammar": dict(gram)}
 
 
 def selector_field(G):

--- a/tests/test_trace.py
+++ b/tests/test_trace.py
@@ -1,5 +1,7 @@
 """Pruebas de trace."""
-from tnfr.trace import register_trace, _callback_names
+import pytest
+
+from tnfr.trace import register_trace, _callback_names, gamma_field, grammar_field
 from tnfr.callback_utils import register_callback, invoke_callbacks
 
 
@@ -57,3 +59,19 @@ def test_callback_names_empty_tuple():
 
     names = _callback_names([(), (foo,)])
     assert names == ["foo"]
+
+
+def test_gamma_field_non_mapping_warns(graph_canon):
+    G = graph_canon()
+    G.graph["GAMMA"] = "not a dict"
+    with pytest.warns(UserWarning):
+        out = gamma_field(G)
+    assert out == {}
+
+
+def test_grammar_field_non_mapping_warns(graph_canon):
+    G = graph_canon()
+    G.graph["GRAMMAR_CANON"] = 123
+    with pytest.warns(UserWarning):
+        out = grammar_field(G)
+    assert out == {}


### PR DESCRIPTION
## Summary
- guard trace helpers against non-mapping `GAMMA` or `GRAMMAR_CANON`
- add regression tests for improper `GAMMA` and `GRAMMAR_CANON` values

## Testing
- `PYTHONPATH=src pytest tests/test_trace.py`

------
https://chatgpt.com/codex/tasks/task_e_68b7178a27f883218ec3684c9be6d7bc