### PR TITLE
Use numeric seed for deterministic node sampling

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -158,7 +158,10 @@ def _update_node_sample(G, *, step: int) -> None:
         return
 
     seed = int(G.graph.get("RANDOM_SEED", 0))
-    rng = random.Random(f"{seed}:{step}")
+    # Ensure deterministic seeding independent of ``PYTHONHASHSEED`` by
+    # combining the user seed and step via bitwise XOR instead of a string
+    # seed, which would rely on Python's randomized hashing of strings.
+    rng = random.Random(seed ^ step)
     G.graph["_node_sample"] = rng.sample(nodes, limit)
 
 # -------------------------

--- a/tests/test_node_sample.py
+++ b/tests/test_node_sample.py
@@ -2,6 +2,10 @@
 from tnfr.dynamics import step
 from tnfr.constants import attach_defaults
 import networkx as nx
+import json
+import os
+import subprocess
+import sys
 
 
 def _build_graph(n):
@@ -28,3 +32,36 @@ def test_node_sample_small_graph():
     step(G, use_Si=False, apply_glyphs=False)
     sample = G.graph.get("_node_sample")
     assert len(sample) == len(G.nodes())
+
+
+def _run_sample_with_hashseed(hashseed):
+    code = r"""
+import json
+import networkx as nx
+from tnfr.constants import attach_defaults
+from tnfr.dynamics import _update_node_sample
+
+def _build_graph(n):
+    G = nx.Graph()
+    attach_defaults(G)
+    for i in range(n):
+        G.add_node(i, θ=0.0, EPI=0.0)
+    return G
+
+G = _build_graph(80)
+G.graph["UM_CANDIDATE_COUNT"] = 10
+G.graph["RANDOM_SEED"] = 123
+_update_node_sample(G, step=5)
+print(json.dumps(G.graph["_node_sample"]))
+"""
+    env = dict(os.environ, PYTHONHASHSEED=str(hashseed))
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, check=True, env=env
+    )
+    return json.loads(result.stdout)
+
+
+def test_node_sample_deterministic_across_hashseed():
+    out1 = _run_sample_with_hashseed(1)
+    out2 = _run_sample_with_hashseed(2)
+    assert out1 == out2


### PR DESCRIPTION
## Summary
- Replace string-based seeding with numeric XOR in node sampling to avoid `PYTHONHASHSEED` nondeterminism
- Add regression test ensuring node sampling is stable across varying `PYTHONHASHSEED`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b71b8f70e4832195b1b37ff5d8bd13