### PR TITLE
refactor: centralizar historial glífico

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -12,9 +12,7 @@ from typing import (
 )
 import logging
 import math
-from collections import deque, Counter
-from itertools import islice
-import heapq
+from collections import deque
 from statistics import fmean, StatisticsError
 import json
 from json import JSONDecodeError
@@ -522,169 +520,14 @@ def push_glyph(nd: Dict[str, Any], glyph: str, window: int) -> None:
         nd["glyph_history"] = hist
     hist.append(str(glyph))
 
-
-def recent_glyph(nd: Dict[str, Any], glyph: str, ventana: int) -> bool:
-    """Indica si ``glyph`` apareció en las últimas ``ventana`` emisiones"""
-    hist = nd.get("glyph_history")
-    gl = str(glyph)
-    if ventana < 0:
-        raise ValueError("ventana debe ser >= 0")
-    if hist and ventana > 0:
-        for reciente in islice(reversed(hist), ventana):
-            if gl == reciente:
-                return True
-    # fallback al glyph dominante actual
-    return get_attr_str(nd, ALIAS_EPI_KIND, "") == gl
-
-# -------------------------
-# Utilidades de historial global
-# -------------------------
-
-class HistoryDict(dict):
-    """Dict especializado que crea deques acotados para series y cuenta usos."""
-
-    def __init__(self, data: Dict[str, Any] | None = None, *, maxlen: int = 0):
-        super().__init__(data or {})
-        self._maxlen = maxlen
-        self._counts: Dict[str, int] = {}
-        self._heap: list[tuple[int, str]] = []
-        if self._maxlen > 0:
-            for k, v in list(self.items()):
-                if isinstance(v, list):
-                    self[k] = deque(v, maxlen=self._maxlen)
-                self._counts.setdefault(k, 0)
-                heapq.heappush(self._heap, (0, k))
-
-    def _compact_heap(self) -> None:
-        """Elimina entradas obsoletas de ``_heap``.
-
-        Las entradas quedan obsoletas cuando la cuenta almacenada no coincide
-        con ``_counts`` o cuando la clave ya no existe en el diccionario. Para
-        evitar que la lista crezca indefinidamente se reconstruye filtrando las
-        entradas válidas y luego se re-heapifica.
-        """
-
-        self._heap = [
-            (cnt, k)
-            for cnt, k in self._heap
-            if k in self and self._counts.get(k) == cnt
-        ]
-        heapq.heapify(self._heap)
-
-    def _maybe_compact(self) -> None:
-        """Compacta ``_heap`` si supera un umbral razonable."""
-
-        if len(self._heap) > len(self) * 2:
-            self._compact_heap()
-
-    def _increment(self, key: str) -> None:
-        cnt = self._counts.get(key, 0) + 1
-        self._counts[key] = cnt
-        heapq.heappush(self._heap, (cnt, key))
-        self._maybe_compact()
-
-    def __getitem__(self, key):  # type: ignore[override]
-        val = super().__getitem__(key)
-        self._increment(key)
-        return val
-
-    def get(self, key, default=None):  # type: ignore[override]
-        return super().get(key, default)
-
-    def tracked_get(self, key, default=None):
-        if key in self:
-            return self[key]
-        return default
-
-    def __setitem__(self, key, value):  # type: ignore[override]
-        super().__setitem__(key, value)
-        self._counts.setdefault(key, 0)
-        heapq.heappush(self._heap, (self._counts[key], key))
-        self._maybe_compact()
-
-    def setdefault(self, key, default=None):  # type: ignore[override]
-        if self._maxlen > 0 and isinstance(default, list):
-            default = deque(default, maxlen=self._maxlen)
-        if key in self:
-            val = self[key]
-        else:
-            val = super().setdefault(key, default)
-            if self._maxlen > 0 and isinstance(val, list):
-                val = deque(val, maxlen=self._maxlen)
-                super().__setitem__(key, val)
-        self._increment(key)
-        return val
-
-    def pop_least_used(self) -> Any:
-        while self._heap:
-            cnt, key = heapq.heappop(self._heap)
-            if self._counts.get(key) == cnt and key in self:
-                self._counts.pop(key, None)
-                return super().pop(key)
-        raise KeyError("HistoryDict is empty")
-
-
-def ensure_history(G) -> Dict[str, Any]:
-    """Garantiza ``G.graph['history']`` y la devuelve.
-
-    Si ``HISTORY_MAXLEN`` > 0, cada serie se almacena en un ``deque`` con ese
-    límite y se eliminan claves poco usadas cuando el historial crece por encima
-    del máximo permitido.
-    """
-
-    maxlen = int(G.graph.get("HISTORY_MAXLEN", get_param(G, "HISTORY_MAXLEN")))
-    hist = G.graph.get("history")
-    if not isinstance(hist, HistoryDict) or hist._maxlen != maxlen:
-        hist = HistoryDict(hist, maxlen=maxlen)
-        G.graph["history"] = hist
-    if maxlen > 0:
-        while len(hist) > maxlen:
-            try:
-                hist.pop_least_used()
-            except KeyError:
-                break
-    return hist
-
-
-def last_glyph(nd: Dict[str, Any]) -> str | None:
-    """Retorna el glyph más reciente del nodo o ``None``."""
-    kind = get_attr_str(nd, ALIAS_EPI_KIND, "")
-    if kind:
-        return kind
-    hist = nd.get("glyph_history")
-    if not hist:
-        return None
-    try:
-        return hist[-1]
-    except IndexError:
-        return None
-
-
-def count_glyphs(
-    G, window: int | None = None, *, last_only: bool = False
-) -> Counter:
-    """Cuenta glyphs recientes en la red.
-
-    Si ``last_only`` es ``True`` cuenta solo el último glyph de cada nodo. En
-    caso contrario se usa el historial ``glyph_history`` limitado a los últimos
-    ``window`` elementos por nodo (o a todo el deque si ``window`` es ``None``).
-    """
-    counts: Counter[str] = Counter()
-    for _, nd in G.nodes(data=True):
-        if last_only:
-            g = last_glyph(nd)
-            seq: Iterable[str] = [g] if g else []
-        else:
-            hist = nd.get("glyph_history")
-            if not hist:
-                continue
-            if window is not None and window > 0:
-                window_int = int(window)
-                seq = islice(reversed(hist), window_int)
-            else:
-                seq = hist
-        counts.update(seq)
-    return counts
+# Importaciones diferidas para evitar ciclos al definir ``get_attr_str`` arriba
+from .glyph_history import (
+    recent_glyph,
+    HistoryDict,
+    ensure_history,
+    last_glyph,
+    count_glyphs,
+)
 # -------------------------
 # Índice de sentido (Si)
 # -------------------------

--- a/src/tnfr/validators.py
+++ b/src/tnfr/validators.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from .constants import ALIAS_EPI, ALIAS_VF, get_param
-from .helpers import get_attr, last_glyph
+from .helpers import get_attr
+from .glyph_history import last_glyph
 from .sense import sigma_vector_from_graph, GLYPHS_CANONICAL_SET
 
 


### PR DESCRIPTION
## Summary
- importa utilidades de historial glífico desde `glyph_history`
- ajusta `validators` para usar `last_glyph` de `glyph_history`

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7369e5e98832191bdc2a0adc80e2b