### PR TITLE
refactor: centralize value conversion utility

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -17,6 +17,7 @@ import logging
 import math
 from itertools import islice
 
+from .value_utils import _convert_value
 T = TypeVar("T")
 
 logger = logging.getLogger(__name__)
@@ -56,30 +57,6 @@ def ensure_collection(
         return data
     except TypeError as exc:
         raise TypeError(f"{it!r} is not iterable") from exc
-
-
-def _convert_value(
-    value: Any,
-    conv: Callable[[Any], T],
-    *,
-    strict: bool = False,
-    key: str | None = None,
-    log_level: int | None = None,
-) -> tuple[bool, T | None]:
-    """Try to convert ``value`` using ``conv`` handling errors."""
-    try:
-        return True, conv(value)
-    except (ValueError, TypeError) as exc:
-        level = log_level if log_level is not None else (
-            logging.ERROR if strict else logging.DEBUG
-        )
-        if key is not None:
-            logger.log(level, "No se pudo convertir el valor para %r: %s", key, exc)
-        else:
-            logger.log(level, "No se pudo convertir el valor: %s", exc)
-        if strict:
-            raise
-        return False, None
 
 
 def normalize_weights(

--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -49,6 +49,7 @@ from .collections_utils import (
     normalize_counter,
     mix_groups,
 )
+from .value_utils import _convert_value
 
 T = TypeVar("T")
 
@@ -176,37 +177,6 @@ def angle_diff(a: float, b: float) -> float:
 # -------------------------
 # Acceso a atributos con alias
 # -------------------------
-
-
-def _convert_value(
-    value: Any,
-    conv: Callable[[Any], T],
-    *,
-    strict: bool = False,
-    key: str | None = None,
-    log_level: int | None = None,
-) -> tuple[bool, T | None]:
-    """Intenta convertir ``value`` usando ``conv`` manejando errores.
-
-    ``log_level`` controla el nivel de logging cuando la conversión falla en
-    modo laxo. Por defecto se usa ``logging.ERROR`` si ``strict`` es ``True`` y
-    ``logging.DEBUG`` en caso contrario.
-    """
-    try:
-        return True, conv(value)
-    except (ValueError, TypeError) as exc:
-        level = log_level if log_level is not None else (
-            logging.ERROR if strict else logging.DEBUG
-        )
-        if key is not None:
-            logger.log(level, "No se pudo convertir el valor para %r: %s", key, exc)
-        else:
-            logger.log(level, "No se pudo convertir el valor: %s", exc)
-        if strict:
-            raise
-        return False, None
-
-
 def _validate_aliases(aliases: Sequence[str]) -> Sequence[str]:
     """Return ``aliases`` ensuring it's a non-empty sequence of strings."""
 

--- a/src/tnfr/value_utils.py
+++ b/src/tnfr/value_utils.py
@@ -1,0 +1,40 @@
+"""Utilities for value conversion."""
+from __future__ import annotations
+
+from typing import Any, Callable, TypeVar
+import logging
+
+T = TypeVar("T")
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["_convert_value"]
+
+
+def _convert_value(
+    value: Any,
+    conv: Callable[[Any], T],
+    *,
+    strict: bool = False,
+    key: str | None = None,
+    log_level: int | None = None,
+) -> tuple[bool, T | None]:
+    """Intenta convertir ``value`` usando ``conv`` manejando errores.
+
+    ``log_level`` controla el nivel de logging cuando la conversión falla en
+    modo laxo. Por defecto se usa ``logging.ERROR`` si ``strict`` es ``True`` y
+    ``logging.DEBUG`` en caso contrario.
+    """
+    try:
+        return True, conv(value)
+    except (ValueError, TypeError) as exc:
+        level = log_level if log_level is not None else (
+            logging.ERROR if strict else logging.DEBUG
+        )
+        if key is not None:
+            logger.log(level, "No se pudo convertir el valor para %r: %s", key, exc)
+        else:
+            logger.log(level, "No se pudo convertir el valor: %s", exc)
+        if strict:
+            raise
+        return False, None


### PR DESCRIPTION
## Summary
- centralize `_convert_value` in new `value_utils` module
- import `_convert_value` from `value_utils` in helpers and collections_utils

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b73accbdc883218599d7a59a45c1c3