### PR TITLE
Replace alias_set assertion with ValueError

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -266,7 +266,8 @@ def alias_set(
     """
     aliases = _validate_aliases(aliases)
     _, val = _convert_value(value, conv, strict=True)
-    assert val is not None
+    if val is None:
+        raise ValueError("conversion yielded None")
     for key in aliases:
         if key in d:
             d[key] = val

--- a/tests/test_alias_set_error.py
+++ b/tests/test_alias_set_error.py
@@ -1,0 +1,8 @@
+"""Pruebas de alias_set para conversiones nulas."""
+import pytest
+from tnfr.helpers import alias_set
+
+def test_alias_set_raises_value_error_on_none():
+    """alias_set debe lanzar ValueError si la conversión produce None."""
+    with pytest.raises(ValueError):
+        alias_set({}, ["x"], lambda v: None, 123)


### PR DESCRIPTION
## Summary
- ensure `alias_set` raises `ValueError` when conversion yields `None`
- add regression test for `alias_set` error case

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b73bbb9d088321bcc4a864c1dcb743