### PR TITLE
refactor: narrow exception handling

### DIFF
--- a/src/tnfr/__init__.py
+++ b/src/tnfr/__init__.py
@@ -14,7 +14,7 @@ except PackageNotFoundError:  # pragma: no cover
 
         with (Path(__file__).resolve().parents[2] / "pyproject.toml").open("rb") as f:
             __version__ = tomllib.load(f)["project"]["version"]
-    except Exception:  # pragma: no cover
+    except (OSError, KeyError, ValueError):  # pragma: no cover
         __version__ = "0+unknown"
 
 # Public API re-exports

--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -60,7 +60,7 @@ def _numpy_with_exc() -> tuple[Any | None, BaseException | None]:
 
     try:  # Optional dependency
         import numpy as _np  # type: ignore
-    except Exception as exc:  # pragma: no cover - handled gracefully
+    except ImportError as exc:  # pragma: no cover - handled gracefully
         return None, exc
     return _np, None
 

--- a/src/tnfr/grammar.py
+++ b/src/tnfr/grammar.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 from typing import Dict, Any, Set, Iterable, Optional, Callable
-import logging
 
 from .constants import (
     DEFAULTS,
@@ -14,8 +13,6 @@ from .constants import (
 from .helpers import get_attr, clamp01
 from .glyph_history import recent_glyph
 from .types import Glyph
-
-logger = logging.getLogger(__name__)
 
 # Nominal glyphs (to avoid typos)
 AL = Glyph.AL
@@ -140,9 +137,6 @@ def _check_repeats(G, n, cand: str, cfg: Dict[str, Any]) -> str:
             return Glyph(fb)
         except (ValueError, TypeError):
             return fb
-        except Exception:
-            logger.debug("Unexpected exception constructing glyph from %r", fb, exc_info=True)
-            raise
     return cand
 
 def _check_force(

--- a/src/tnfr/operators.py
+++ b/src/tnfr/operators.py
@@ -165,7 +165,7 @@ def random_jitter(
     if cache is None:
         try:
             cache_size = get_param(node.G, "JITTER_CACHE_SIZE")  # type: ignore[attr-defined]
-        except Exception:
+        except (AttributeError, KeyError):
             cache_size = DEFAULTS["JITTER_CACHE_SIZE"]
         rng = _get_rng(scope, base_seed, seed_key, cache_size)
     else:

--- a/tests/test_config_apply.py
+++ b/tests/test_config_apply.py
@@ -6,7 +6,7 @@ from tnfr.config import load_config, apply_config
 
 try:  # pragma: no cover - dependencia opcional
     import yaml  # type: ignore
-except Exception:  # pragma: no cover - skip if not installed
+except ImportError:  # pragma: no cover - skip if not installed
     yaml = None
 
 


### PR DESCRIPTION
## Summary
- avoid swallowing errors by catching only expected exceptions
- tidy fallback logic for optional dependencies
- drop unused debug logging and narrow optional dependency import in tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b73dbd5884832192a4d38f82e54538