### PR TITLE
Log known callback errors and narrow exception handling

### DIFF
--- a/src/tnfr/callback_utils.py
+++ b/src/tnfr/callback_utils.py
@@ -4,10 +4,13 @@ from __future__ import annotations
 from typing import Callable, Any, Optional
 from enum import Enum
 from collections import defaultdict
+import logging
 
 from .constants import DEFAULTS
 
 __all__ = ["CallbackEvent", "register_callback", "invoke_callbacks"]
+
+logger = logging.getLogger(__name__)
 
 
 class CallbackEvent(str, Enum):
@@ -69,7 +72,8 @@ def invoke_callbacks(G, event: CallbackEvent | str, ctx: dict | None = None):
     for name, fn in list(cbs):
         try:
             fn(G, ctx)
-        except (KeyError, ValueError, TypeError) as e:
+        except (KeyError, AttributeError, TypeError) as e:
+            logger.warning("callback %r failed for %s: %s", name, event, e)
             if strict:
                 raise
             G.graph.setdefault("_callback_errors", []).append({

--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -1185,7 +1185,8 @@ def _update_history(G) -> None:
             hist.setdefault("iota", []).append(
                 hist["C_steps"][-1] * hist["stable_frac"][-1]
             )
-    except (KeyError, ValueError, TypeError):
+    except (KeyError, AttributeError, TypeError) as exc:
+        logger.debug("observer update failed: %s", exc)
         # observadores son opcionales; si fallan se ignoran
         pass
   
@@ -1214,6 +1215,7 @@ def _update_history(G) -> None:
             hist["Si_mean"].append(0.0)
             hist["Si_hi_frac"].append(0.0)
             hist["Si_lo_frac"].append(0.0)
-    except (KeyError, ValueError, TypeError):
+    except (KeyError, AttributeError, TypeError) as exc:
+        logger.debug("Si aggregation failed: %s", exc)
         # si aún no se calculó Si este paso, no interrumpimos
         pass


### PR DESCRIPTION
## Summary
- Log and collect callback errors while only catching expected KeyError/AttributeError/TypeError
- Log failures from optional observers and Si aggregation, limiting exception handling to expected types

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b73eb3705883218acfd4d67b01cb6e