### PR TITLE
Avoid unnecessary node listing during sampling

### DIFF
--- a/src/tnfr/dynamics.py
+++ b/src/tnfr/dynamics.py
@@ -150,13 +150,14 @@ def _update_node_sample(G, *, step: int) -> None:
     is non‑positive, the full node set is used and sampling is effectively
     disabled.
     """
-
     limit = int(G.graph.get("UM_CANDIDATE_COUNT", 0))
-    nodes = list(G.nodes())
-    if limit <= 0 or len(nodes) < 50 or limit >= len(nodes):
-        G.graph["_node_sample"] = nodes
+    n = G.number_of_nodes()
+    if limit <= 0 or n < 50 or limit >= n:
+        # Avoid materialising the node view unless strictly necessary.
+        G.graph["_node_sample"] = G.nodes()
         return
 
+    nodes = list(G.nodes())
     seed = int(G.graph.get("RANDOM_SEED", 0))
     # Ensure deterministic seeding independent of ``PYTHONHASHSEED`` by
     # combining the user seed and step via bitwise XOR instead of a string

--- a/tests/test_node_sample.py
+++ b/tests/test_node_sample.py
@@ -31,6 +31,7 @@ def test_node_sample_small_graph():
     G.graph["UM_CANDIDATE_COUNT"] = 5
     step(G, use_Si=False, apply_glyphs=False)
     sample = G.graph.get("_node_sample")
+    assert not isinstance(sample, list)
     assert len(sample) == len(G.nodes())
 
 


### PR DESCRIPTION
## Summary
- Use `G.number_of_nodes()` before building a list of nodes, only materialising the list when sampling is needed.
- Store `G.nodes()` directly when sampling isn't required, avoiding unnecessary allocations.
- Extend node sampling tests to verify that small graphs retain a view instead of a list.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b73f91dda08321b208d39b9d863e05