### PR TITLE
Add file safety checks

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -118,8 +118,12 @@ def _default(obj: Any) -> Any:
 
 
 def _save_json(path: str, data: Any) -> None:
-    with open(path, "w", encoding="utf-8") as f:
-        json.dump(data, f, ensure_ascii=False, indent=2, default=_default)
+    ensure_parent(path)
+    try:
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(data, f, ensure_ascii=False, indent=2, default=_default)
+    except OSError as e:
+        raise OSError(f"Failed to write JSON file {path}: {e}") from e
 
 
 def _str2bool(s: str) -> bool:
@@ -193,11 +197,9 @@ def _persist_history(G: nx.Graph, args: argparse.Namespace) -> None:
     """Guardar o exportar el histórico si se solicitó."""
     if getattr(args, "save_history", None):
         path = args.save_history
-        ensure_parent(path)
         _save_json(path, G.graph.get("history", {}))
     if getattr(args, "export_history_base", None):
         base = args.export_history_base
-        ensure_parent(base)
         export_history(G, base, fmt=getattr(args, "export_format", "json"))
 
 
@@ -407,7 +409,6 @@ def cmd_metrics(args: argparse.Namespace) -> int:
         "glyphogram": {k: v[:10] for k, v in glyph.items()},
     }
     if args.save:
-        ensure_parent(args.save)
         _save_json(args.save, out)
     else:
         logger.info("%s", json.dumps(out, ensure_ascii=False, indent=2))

--- a/src/tnfr/metrics/export.py
+++ b/src/tnfr/metrics/export.py
@@ -11,11 +11,15 @@ from .core import glyphogram_series
 
 
 def _write_csv(path, headers, rows):
-    with open(path, "w", newline="", encoding="utf-8") as f:
-        writer = csv.writer(f)
-        writer.writerow(headers)
-        for row in rows:
-            writer.writerow(row)
+    ensure_parent(path)
+    try:
+        with open(path, "w", newline="", encoding="utf-8") as f:
+            writer = csv.writer(f)
+            writer.writerow(headers)
+            for row in rows:
+                writer.writerow(row)
+    except OSError as e:
+        raise OSError(f"Failed to write CSV file {path}: {e}") from e
 
 
 def _iter_glif_rows(glyph):
@@ -94,5 +98,10 @@ def export_history(G, base_path: str, fmt: str = "csv") -> None:
             _write_csv(base_path + suffix, headers, rows)
     else:
         data = {"glyphogram": glyph, "sigma": sigma, "morph": morph, "epi_support": epi_supp}
-        with open(base_path + ".json", "w", encoding="utf-8") as f:
-            json.dump(data, f, ensure_ascii=False, indent=2)
+        json_path = base_path + ".json"
+        ensure_parent(json_path)
+        try:
+            with open(json_path, "w", encoding="utf-8") as f:
+                json.dump(data, f, ensure_ascii=False, indent=2)
+        except OSError as e:
+            raise OSError(f"Failed to write JSON file {json_path}: {e}") from e


### PR DESCRIPTION
## Summary
- ensure parent directories exist before writing metrics or history files
- handle file write failures with clear `OSError` messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b74167a6688321ba993c4d43f8ffbb