### PR TITLE
Use argparse.BooleanOptionalAction for grammar flag

### DIFF
--- a/src/tnfr/cli.py
+++ b/src/tnfr/cli.py
@@ -126,25 +126,17 @@ def _save_json(path: str, data: Any) -> None:
         raise OSError(f"Failed to write JSON file {path}: {e}") from e
 
 
-def _str2bool(s: str) -> bool:
-    s = s.lower()
-    if s in {"true", "1", "yes", "y"}:
-        return True
-    if s in {"false", "0", "no", "n"}:
-        return False
-    raise argparse.ArgumentTypeError("expected true/false")
-
-
 # Metadatos para las opciones de gramática y del glyph
+# Utiliza acciones y tipos estándar de ``argparse`` en lugar de conversores personalizados.
 GRAMMAR_ARG_SPECS = [
-    ("--grammar.enabled", _str2bool),
-    ("--grammar.zhir_requires_oz_window", int),
-    ("--grammar.zhir_dnfr_min", float),
-    ("--grammar.thol_min_len", int),
-    ("--grammar.thol_max_len", int),
-    ("--grammar.thol_close_dnfr", float),
-    ("--grammar.si_high", float),
-    ("--glyph.hysteresis_window", int),
+    ("--grammar.enabled", {"action": argparse.BooleanOptionalAction}),
+    ("--grammar.zhir_requires_oz_window", {"type": int}),
+    ("--grammar.zhir_dnfr_min", {"type": float}),
+    ("--grammar.thol_min_len", {"type": int}),
+    ("--grammar.thol_max_len", {"type": int}),
+    ("--grammar.thol_close_dnfr", {"type": float}),
+    ("--grammar.si_high", {"type": float}),
+    ("--glyph.hysteresis_window", {"type": int}),
 ]
 
 
@@ -287,9 +279,9 @@ def add_common_args(parser: argparse.ArgumentParser) -> None:
 def add_grammar_args(parser: argparse.ArgumentParser) -> None:
     """Agrega las opciones de gramática y de histéresis del glyph."""
     group = parser.add_argument_group("Grammar")
-    for opt, typ in GRAMMAR_ARG_SPECS:
+    for opt, kwargs in GRAMMAR_ARG_SPECS:
         dest = opt.lstrip("-").replace(".", "_")
-        group.add_argument(opt, dest=dest, type=typ, default=None)
+        group.add_argument(opt, dest=dest, default=None, **kwargs)
 
 
 def add_grammar_selector_args(parser: argparse.ArgumentParser) -> None:

--- a/tests/test_cli_sanity.py
+++ b/tests/test_cli_sanity.py
@@ -53,7 +53,6 @@ def test_args_to_dict_nested_options():
             "--nodes",
             "5",
             "--grammar.enabled",
-            "true",
             "--grammar.thol_min_len",
             "7",
         ]


### PR DESCRIPTION
## Summary
- replace custom `_str2bool` with `argparse.BooleanOptionalAction`
- simplify grammar argument registration to use standard argparse actions
- update CLI tests for new boolean flag semantics

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7427303d08321bf827f59e064ee54