### PR TITLE
refactor: unify push_glyph implementation

### DIFF
--- a/src/tnfr/helpers.py
+++ b/src/tnfr/helpers.py
@@ -12,7 +12,6 @@ from typing import (
 )
 import logging
 import math
-from collections import deque
 from statistics import fmean, StatisticsError
 import json
 from json import JSONDecodeError
@@ -483,16 +482,9 @@ def fase_media(obj, n=None) -> float:
 # Historial de glyphs por nodo
 # -------------------------
 
-def push_glyph(nd: Dict[str, Any], glyph: str, window: int) -> None:
-    """Añade ``glyph`` al historial del nodo con tamaño máximo ``window``."""
-    hist = nd.get("glyph_history")
-    if hist is None or hist.maxlen != window:
-        hist = deque(hist or [], maxlen=window)
-        nd["glyph_history"] = hist
-    hist.append(str(glyph))
-
 # Importaciones diferidas para evitar ciclos al definir ``get_attr_str`` arriba
 from .glyph_history import (
+    push_glyph,
     recent_glyph,
     HistoryDict,
     ensure_history,


### PR DESCRIPTION
## Summary
- re-export push_glyph via helpers by importing it from glyph_history

## Testing
- `PYTHONPATH=src pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b746e0624483218d02118aa8a0643f