### PR TITLE
chore: remove unused typing imports

### DIFF
--- a/src/tnfr/collections_utils.py
+++ b/src/tnfr/collections_utils.py
@@ -6,10 +6,8 @@ from typing import (
     Sequence,
     Dict,
     Any,
-    Callable,
     TypeVar,
     Mapping,
-    Optional,
     Collection,
     cast,
 )


### PR DESCRIPTION
## Summary
- remove unused Callable and Optional typing imports in collections utils

## Testing
- `ruff check src/tnfr/collections_utils.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'tnfr')*


------
https://chatgpt.com/codex/tasks/task_e_68b74fd4f61c832181d40661661eb8d3